### PR TITLE
Crypto stream

### DIFF
--- a/cryptostream/crypto_stream.go
+++ b/cryptostream/crypto_stream.go
@@ -1,0 +1,31 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamKeyBytes() int {
+	return int(C.crypto_stream_keybytes())
+}
+
+func  CryptoStreamNonceBytes() int {
+	return int(C.crypto_stream_noncebytes())
+}
+
+func CryptoStreamPrimitive() string {
+	return C.GoString(C.crypto_stream_primitive())
+}
+
+func CryptoStream(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamNonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamKeyBytes(), "key")
+	return CryptoStreamXSalsa20(clen, n, k)
+}
+
+func CryptoStreamXOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamNonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamKeyBytes(), "key")
+	return CryptoStreamXSalsa20XOR(m, n, k)
+}

--- a/cryptostream/crypto_stream_chacha20.go
+++ b/cryptostream/crypto_stream_chacha20.go
@@ -1,0 +1,125 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamChaCha20KeyBytes() int {
+	return int(C.crypto_stream_chacha20_keybytes())
+}
+
+func CryptoStreamChaCha20NonceBytes() int {
+	return int(C.crypto_stream_chacha20_noncebytes())
+}
+
+func CryptoStreamChaCha20(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20KeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_chacha20(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamChaCha20XOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20KeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_chacha20_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamChaCha20XORIC(m []byte, n []byte, ic uint64, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20KeyBytes(), "key")
+
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_chacha20_xor_ic(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(C.uint64_t)(ic),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamChaCha20Keygen() []byte {
+//	c := make([]byte, CryptoStreamChaCha20KeyBytes())
+//	C.crypto_stream_chacha20_keygen((*C.uchar)(&c[0]))
+//	return c
+//}
+
+func CryptoStreamChaCha20IETFKeyBytes() int {
+	// Requires 1.0.12
+	// return int(C.crypto_stream_chacha20_ietf_keybytes())
+	return CryptoStreamChaCha20KeyBytes()
+}
+
+func CryptoStreamChaCha20IETFNonceBytes() int {
+	return int(C.crypto_stream_chacha20_ietf_noncebytes())
+}
+
+func CryptoStreamChaCha20IETF(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20IETFNonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20IETFKeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_chacha20_ietf(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamChaCha20IETFXOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20IETFNonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20IETFKeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_chacha20_ietf_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamChaCha20IETFXORIC(m []byte, n []byte, ic uint32, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamChaCha20IETFNonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamChaCha20IETFKeyBytes(), "key")
+
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_chacha20_ietf_xor_ic(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(C.uint32_t)(ic),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamChaCha20IETFKeygen() []byte {
+//	c := make([]byte, CryptoStreamChaCha20IETFKeyBytes())
+//	C.crypto_stream_chacha20_ietf_keygen((*C.uchar)(&c[0]))
+//	return c
+//}

--- a/cryptostream/crypto_stream_salsa20.go
+++ b/cryptostream/crypto_stream_salsa20.go
@@ -1,0 +1,65 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamSalsa20KeyBytes() int {
+	return int(C.crypto_stream_salsa20_keybytes())
+}
+
+func CryptoStreamSalsa20NonceBytes() int {
+	return int(C.crypto_stream_salsa20_noncebytes())
+}
+
+func CryptoStreamSalsa20(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa20KeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_salsa20(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamSalsa20XOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa20KeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_salsa20_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamSalsa20XORIC(m []byte, n []byte, ic uint64, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa20KeyBytes(), "key")
+
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_salsa20_xor_ic(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(C.uint64_t)(ic),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamSalsa20Keygen() []byte {
+//	c := make([]byte, CryptoStreamSalsa20KeyBytes())
+//	C.crypto_stream_salsa20_keygen((*C.uchar)(&c[0]))
+//	return c
+//}

--- a/cryptostream/crypto_stream_salsa2012.go
+++ b/cryptostream/crypto_stream_salsa2012.go
@@ -1,0 +1,49 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamSalsa2012KeyBytes() int {
+	return int(C.crypto_stream_salsa2012_keybytes())
+}
+
+func CryptoStreamSalsa2012NonceBytes() int {
+	return int(C.crypto_stream_salsa2012_noncebytes())
+}
+
+func CryptoStreamSalsa2012(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa2012NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa2012KeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_salsa2012(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamSalsa2012XOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa2012NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa2012KeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_salsa2012_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamSalsa2012Keygen() []byte {
+//	c := make([]byte, CryptoStreamSalsa2012KeyBytes())
+//	C.crypto_stream_salsa2012_keygen((*C.uchar)(&c[0]))
+//	return c
+//}

--- a/cryptostream/crypto_stream_salsa208.go
+++ b/cryptostream/crypto_stream_salsa208.go
@@ -1,0 +1,49 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamSalsa208KeyBytes() int {
+	return int(C.crypto_stream_salsa208_keybytes())
+}
+
+func CryptoStreamSalsa208NonceBytes() int {
+	return int(C.crypto_stream_salsa208_noncebytes())
+}
+
+func CryptoStreamSalsa208(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa208NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa208KeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_salsa208(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamSalsa208XOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamSalsa208NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamSalsa208KeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_salsa208_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamSalsa208Keygen() []byte {
+//	c := make([]byte, CryptoStreamSalsa208KeyBytes())
+//	C.crypto_stream_salsa208_keygen((*C.uchar)(&c[0]))
+//	return c
+//}

--- a/cryptostream/crypto_stream_xsalsa20.go
+++ b/cryptostream/crypto_stream_xsalsa20.go
@@ -1,0 +1,65 @@
+package cryptostream
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+func CryptoStreamXSalsa20KeyBytes() int {
+	return int(C.crypto_stream_xsalsa20_keybytes())
+}
+
+func CryptoStreamXSalsa20NonceBytes() int {
+	return int(C.crypto_stream_xsalsa20_noncebytes())
+}
+
+func CryptoStreamXSalsa20(clen int, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamXSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamXSalsa20KeyBytes(), "key")
+	c := make([]byte, clen)
+	exit := int(C.crypto_stream_xsalsa20(
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(clen),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamXSalsa20XOR(m []byte, n []byte, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamXSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamXSalsa20KeyBytes(), "key")
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_xsalsa20_xor(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+func CryptoStreamXSalsa20XORIC(m []byte, n []byte, ic uint64, k []byte) ([]byte, int) {
+	support.CheckSize(n, CryptoStreamXSalsa20NonceBytes(), "nonce")
+	support.CheckSize(k, CryptoStreamXSalsa20KeyBytes(), "key")
+
+	c := make([]byte, len(m))
+	exit := int(C.crypto_stream_xsalsa20_xor_ic(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(C.uint64_t)(ic),
+		(*C.uchar)(&k[0])))
+
+	return c, exit
+}
+
+// Requires 1.0.12
+//func CryptoStreamXSalsa20Keygen() []byte {
+//	c := make([]byte, CryptoStreamXSalsa20KeyBytes())
+//	C.crypto_stream_xsalsa20_keygen((*C.uchar)(&c[0]))
+//	return c
+//}


### PR DESCRIPTION
This wraps all `crypto_stream` functions. I have commented the functions that were added in libsodium 1.0.12 (released today) for compatibility. I will open a separate pull request adding those and XChaCha20 after this request has been merged.