### PR TITLE
Wrap sodium/version

### DIFF
--- a/sodium/version.go
+++ b/sodium/version.go
@@ -1,0 +1,18 @@
+package sodium
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+
+func SodiumVersionString() string {
+	return C.GoString(C.sodium_version_string())
+}
+
+func SodiumLibaryVersionMajor() int {
+	return int(C.sodium_library_version_major())
+}
+
+func SodiumLibaryVersionMinor() int {
+	return int(C.sodium_library_version_minor())
+}


### PR DESCRIPTION
`sodium_library_minimal()` from libsodium 1.0.12 has not been included but will be included in a separate pull request.