### PR TITLE
Add, test and fix CryptoAEADAES256GCM functions

### DIFF
--- a/cryptoaead/crypto_aead_aes256gcm.go
+++ b/cryptoaead/crypto_aead_aes256gcm.go
@@ -6,12 +6,17 @@ package cryptoaead
 import "C"
 import "github.com/GoKillers/libsodium-go/support"
 
+func CryptoAEADAES256GCMIsAvailable() bool {
+	C.sodium_init()
+	return int(C.crypto_aead_aes256gcm_is_available()) != 0
+}
+
 func CryptoAEADAES256GCMKeyBytes() int {
 	return int(C.crypto_aead_aes256gcm_keybytes())
 }
 
 func CryptoAEADAES256GCMNSecBytes() int {
-	return int(C.crypto_aead_aes256gcm_keybytes())
+	return int(C.crypto_aead_aes256gcm_nsecbytes())
 }
 
 func CryptoAEADAES256GCMNPubBytes() int {
@@ -26,47 +31,95 @@ func CryptoAEADAES256GCMStateBytes() int {
 	return int(C.crypto_aead_aes256gcm_statebytes())
 }
 
-func CryptoAESAES256GCMIsAvailable() int {
-	return int(C.crypto_aead_aes256gcm_is_available())
-}
-
-func CryptoAEADAES256GCMEncrypt(m []byte, ad []byte, nsec []byte, npub []byte, k []byte) ([]byte, int) {
+func CryptoAEADAES256GCMEncrypt(m []byte, ad []byte, npub []byte, k []byte) ([]byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+
 	c := make([]byte, len(m)+CryptoAEADAES256GCMABytes())
-	cLen := len(c)
-	cLenLongLong := (C.ulonglong(cLen))
+	cLen := C.ulonglong(len(c))
+
 	exit := int(C.crypto_aead_aes256gcm_encrypt(
-		(*C.uchar)(&c[0]),
-		&cLenLongLong,
-		(*C.uchar)(&m[0]),
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.ulonglong)(&cLen),
+		(*C.uchar)(support.BytePointer(m)),
 		(C.ulonglong)(len(m)),
-		(*C.uchar)(&ad[0]),
+		(*C.uchar)(support.BytePointer(ad)),
 		(C.ulonglong)(len(ad)),
-		(*C.uchar)(&nsec[0]),
+		(*C.uchar)(nil),
 		(*C.uchar)(&npub[0]),
 		(*C.uchar)(&k[0])))
 
 	return c, exit
 }
 
-func CryptoAEADAES256GCMDecrypt(nsec []byte, c []byte, ad []byte, npub []byte, k []byte) ([]byte, int) {
+func CryptoAEADAES256GCMDecrypt(c []byte, ad []byte, npub []byte, k []byte) ([]byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+	support.CheckSizeMin(c, CryptoAEADAES256GCMABytes(), "ciphertext")
+
 	m := make([]byte, len(c)-CryptoAEADAES256GCMABytes())
-	mLen := len(m)
-	mLenLongLong := (C.ulonglong)(mLen)
+	mLen := (C.ulonglong)(len(m))
 
 	exit := int(C.crypto_aead_aes256gcm_decrypt(
-		(*C.uchar)(&m[0]),
-		&mLenLongLong,
-		(*C.uchar)(&nsec[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.ulonglong)(&mLen),
+		(*C.uchar)(nil),
 		(*C.uchar)(&c[0]),
 		(C.ulonglong)(len(c)),
-		(*C.uchar)(&ad[0]),
+		(*C.uchar)(support.BytePointer(ad)),
 		(C.ulonglong)(len(ad)),
 		(*C.uchar)(&npub[0]),
 		(*C.uchar)(&k[0])))
 
 	return m, exit
+}
+
+func CryptoAEADAES256GCMEncryptDetached(m []byte, ad []byte, npub []byte, k []byte) ([]byte, []byte, int) {
+	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+
+	c := make([]byte, len(m))
+	mac := make([]byte , CryptoAEADAES256GCMABytes())
+	macLen := C.ulonglong(len(c))
+
+	exit := int(C.crypto_aead_aes256gcm_encrypt_detached(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.ulonglong)(&macLen),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(nil),
+		(*C.uchar)(&npub[0]),
+		(*C.uchar)(&k[0])))
+
+	return c, mac, exit
+}
+
+func CryptoAEADAES256GCMDecryptDetached(c, mac, ad, npub, k []byte) ([]byte, int) {
+	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+	support.CheckSize(mac, CryptoAEADAES256GCMABytes(), "mac")
+
+	m := make([]byte, len(c))
+
+	exit := int(C.crypto_aead_aes256gcm_decrypt_detached(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(nil),
+		(*C.uchar)(support.BytePointer(c)),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(&npub[0]),
+		(*C.uchar)(&k[0])))
+
+	return m, exit
+}
+
+func CryptoAEADAES256GCMKeyGen() []byte {
+	k := make([]byte, CryptoAEADAES256GCMKeyBytes())
+	C.crypto_aead_aes256gcm_keygen((*C.uchar)(&k[0]))
+	return k
 }

--- a/cryptoaead/crypto_aead_aes256gcm.go
+++ b/cryptoaead/crypto_aead_aes256gcm.go
@@ -4,7 +4,10 @@ package cryptoaead
 // #include <stdlib.h>
 // #include <sodium.h>
 import "C"
-import "github.com/GoKillers/libsodium-go/support"
+import (
+	"github.com/GoKillers/libsodium-go/support"
+	"unsafe"
+)
 
 func CryptoAEADAES256GCMIsAvailable() bool {
 	C.sodium_init()
@@ -31,7 +34,7 @@ func CryptoAEADAES256GCMStateBytes() int {
 	return int(C.crypto_aead_aes256gcm_statebytes())
 }
 
-func CryptoAEADAES256GCMEncrypt(m []byte, ad []byte, npub []byte, k []byte) ([]byte, int) {
+func CryptoAEADAES256GCMEncrypt(m, ad, npub, k []byte) ([]byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
 
@@ -52,7 +55,7 @@ func CryptoAEADAES256GCMEncrypt(m []byte, ad []byte, npub []byte, k []byte) ([]b
 	return c, exit
 }
 
-func CryptoAEADAES256GCMDecrypt(c []byte, ad []byte, npub []byte, k []byte) ([]byte, int) {
+func CryptoAEADAES256GCMDecrypt(c, ad, npub, k []byte) ([]byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
 	support.CheckSizeMin(c, CryptoAEADAES256GCMABytes(), "ciphertext")
@@ -74,7 +77,7 @@ func CryptoAEADAES256GCMDecrypt(c []byte, ad []byte, npub []byte, k []byte) ([]b
 	return m, exit
 }
 
-func CryptoAEADAES256GCMEncryptDetached(m []byte, ad []byte, npub []byte, k []byte) ([]byte, []byte, int) {
+func CryptoAEADAES256GCMEncryptDetached(m, ad, npub, k []byte) ([]byte, []byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
 
@@ -114,6 +117,105 @@ func CryptoAEADAES256GCMDecryptDetached(c, mac, ad, npub, k []byte) ([]byte, int
 		(C.ulonglong)(len(ad)),
 		(*C.uchar)(&npub[0]),
 		(*C.uchar)(&k[0])))
+
+	return m, exit
+}
+
+func CryptoAEADAES256CGMBeforeNM(k []byte) ([]byte, int) {
+	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
+
+	ctx := make([]byte, CryptoAEADAES256GCMStateBytes())
+
+	exit := int(C.crypto_aead_aes256gcm_beforenm(
+		(*C.crypto_aead_aes256gcm_state)(unsafe.Pointer(&ctx[0])),
+		(*C.uchar)(&k[0])))
+
+	return ctx, exit
+}
+
+func CryptoAEADAES256GCMEncryptAfterNM(m, ad, npub, ctx []byte) ([]byte, int) {
+	support.CheckSize(ctx, CryptoAEADAES256GCMStateBytes(), "context")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+
+	c := make([]byte, len(m)+CryptoAEADAES256GCMABytes())
+	cLen := C.ulonglong(len(c))
+
+	exit := int(C.crypto_aead_aes256gcm_encrypt_afternm(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.ulonglong)(&cLen),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(nil),
+		(*C.uchar)(&npub[0]),
+		(*[512]C.uchar)(unsafe.Pointer(&ctx[0]))))
+
+	return c, exit
+}
+
+func CryptoAEADAES256GCMDecryptAfterNM(c, ad, npub, ctx []byte) ([]byte, int) {
+	support.CheckSize(ctx, CryptoAEADAES256GCMStateBytes(), "context")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+	support.CheckSizeMin(c, CryptoAEADAES256GCMABytes(), "ciphertext")
+
+	m := make([]byte, len(c)-CryptoAEADAES256GCMABytes())
+	mLen := (C.ulonglong)(len(m))
+
+	exit := int(C.crypto_aead_aes256gcm_decrypt_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.ulonglong)(&mLen),
+		(*C.uchar)(nil),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(&npub[0]),
+		(*[512]C.uchar)(unsafe.Pointer(&ctx[0]))))
+
+	return m, exit
+}
+
+func CryptoAEADAES256GCMEncryptDetachedAfterNM(m, ad, npub, ctx []byte) ([]byte, []byte, int) {
+	support.CheckSize(ctx, CryptoAEADAES256GCMStateBytes(), "context")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+
+	c := make([]byte, len(m))
+	mac := make([]byte , CryptoAEADAES256GCMABytes())
+	macLen := C.ulonglong(len(c))
+
+	exit := int(C.crypto_aead_aes256gcm_encrypt_detached_afternm(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.ulonglong)(&macLen),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(nil),
+		(*C.uchar)(&npub[0]),
+		(*[512]C.uchar)(unsafe.Pointer(&ctx[0]))))
+
+	return c, mac, exit
+}
+
+func CryptoAEADAES256GCMDecryptDetachedAfterNM(c, mac, ad, npub, ctx []byte) ([]byte, int) {
+	support.CheckSize(ctx, CryptoAEADAES256GCMStateBytes(), "context")
+	support.CheckSize(npub, CryptoAEADAES256GCMNPubBytes(), "public nonce")
+	support.CheckSize(mac, CryptoAEADAES256GCMABytes(), "mac")
+
+	m := make([]byte, len(c))
+
+	exit := int(C.crypto_aead_aes256gcm_decrypt_detached_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(nil),
+		(*C.uchar)(support.BytePointer(c)),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(ad)),
+		(C.ulonglong)(len(ad)),
+		(*C.uchar)(&npub[0]),
+		(*[512]C.uchar)(unsafe.Pointer(&ctx[0]))))
 
 	return m, exit
 }

--- a/cryptoaead/crypto_aead_aes256gcm.go
+++ b/cryptoaead/crypto_aead_aes256gcm.go
@@ -121,7 +121,7 @@ func CryptoAEADAES256GCMDecryptDetached(c, mac, ad, npub, k []byte) ([]byte, int
 	return m, exit
 }
 
-func CryptoAEADAES256CGMBeforeNM(k []byte) ([]byte, int) {
+func CryptoAEADAES256GCMBeforeNM(k []byte) ([]byte, int) {
 	support.CheckSize(k, CryptoAEADAES256GCMKeyBytes(), "secret key")
 
 	ctx := make([]byte, CryptoAEADAES256GCMStateBytes())

--- a/cryptoaead/crypto_aead_aes256gcm_test.go
+++ b/cryptoaead/crypto_aead_aes256gcm_test.go
@@ -18,7 +18,7 @@ type Test struct {
 func TestCryptoAEADAES256GCM(t *testing.T) {
 	// Skip the test if unsupported on this platform
 	if !CryptoAEADAES256GCMIsAvailable() {
-		t.Skip()
+		t.Skip("The CPU does not support this implementation of AES256GCM.")
 	}
 
 	// Test the key generation

--- a/cryptoaead/crypto_aead_aes256gcm_test.go
+++ b/cryptoaead/crypto_aead_aes256gcm_test.go
@@ -6,13 +6,15 @@ import (
 	"github.com/google/gofuzz"
 )
 
-var testCount = 1000000
+var testCount = 100000
 
 type Test struct {
 	Message    []byte
 	Ad         []byte
 	Key        [32]byte
 	Nonce      [12]byte
+	Ciphertext []byte
+	Mac        []byte
 }
 
 func TestCryptoAEADAES256GCM(t *testing.T) {
@@ -24,6 +26,11 @@ func TestCryptoAEADAES256GCM(t *testing.T) {
 	// Test the key generation
 	if len(CryptoAEADAES256GCMKeyGen()) != CryptoAEADAES256GCMKeyBytes() {
 		t.Error("Generated key has the wrong length")
+	}
+
+	// Test the length of NSecBytes
+	if CryptoAEADAES256GCMNSecBytes() != 0 {
+		t.Errorf("CryptoAEADAES256GCMNSecBytes is %v but should be %v", CryptoAEADAES256GCMNSecBytes(), 0)
 	}
 
 	// Fuzzing
@@ -38,32 +45,58 @@ func TestCryptoAEADAES256GCM(t *testing.T) {
 		// Fuzz the test struct
 		f.Fuzz(&test)
 
+		// Create a key context
+		ctx, err := CryptoAEADAES256CGMBeforeNM(test.Key[:])
+		if err != 0 {
+			t.Error("Context creation failed for %+v", test)
+		}
+
 		// Detached encryption test
-		c, mac, err = CryptoAEADAES256GCMEncryptDetached(test.Message, test.Ad, test.Nonce[:], test.Key[:])
+		test.Ciphertext, test.Mac, err = CryptoAEADAES256GCMEncryptDetached(test.Message, test.Ad, test.Nonce[:], test.Key[:])
 		if err != 0 {
 			t.Errorf("Detached encryption failed for %+v", test)
-			t.FailNow()
+		}
+
+		// Detached encryption with context
+		c, mac, err = CryptoAEADAES256GCMEncryptDetachedAfterNM(test.Message, test.Ad, test.Nonce[:], ctx)
+		if err != 0 || !bytes.Equal(c, test.Ciphertext) || !bytes.Equal(mac, test.Mac) {
+			t.Errorf("Detached encryption with context failed for %+v", test)
 		}
 
 		// Encryption test
 		ec, err = CryptoAEADAES256GCMEncrypt(test.Message, test.Ad, test.Nonce[:], test.Key[:])
-		if err != 0 || !bytes.Equal(ec, append(c, mac...)) {
+		if err != 0 || !bytes.Equal(ec, append(test.Ciphertext, test.Mac...)) {
 			t.Errorf("Encryption failed for %+v", test)
-			t.FailNow()
+		}
+
+		// Encryption with context
+		ec, err = CryptoAEADAES256GCMEncryptAfterNM(test.Message, test.Ad, test.Nonce[:], ctx)
+		if err != 0 || !bytes.Equal(ec, append(test.Ciphertext, test.Mac...)) {
+			t.Errorf("Encryption with context failed for %+v", test)
 		}
 
 		// Detached decryption test
 		m, err = CryptoAEADAES256GCMDecryptDetached(c, mac, test.Ad, test.Nonce[:], test.Key[:])
 		if err != 0 || !bytes.Equal(m, test.Message) {
 			t.Errorf("Detached decryption failed for %+v", test)
-			t.FailNow()
+		}
+
+		// Detached decryption with context test
+		m, err = CryptoAEADAES256GCMDecryptDetachedAfterNM(c, mac, test.Ad, test.Nonce[:], ctx)
+		if err != 0 || !bytes.Equal(m, test.Message) {
+			t.Errorf("Detached decryption with context failed for %+v", test)
 		}
 
 		// Decryption test
 		m, err = CryptoAEADAES256GCMDecrypt(ec, test.Ad, test.Nonce[:], test.Key[:])
 		if err != 0 || !bytes.Equal(m, test.Message) {
 			t.Errorf("Decryption failed for %+v", test)
-			t.FailNow()
+		}
+
+		// Decryption with context test
+		m, err = CryptoAEADAES256GCMDecryptAfterNM(ec, test.Ad, test.Nonce[:], ctx)
+		if err != 0 || !bytes.Equal(m, test.Message) {
+			t.Errorf("Decryption with context failed for %+v", test)
 		}
 	}
 	t.Logf("Completed %v tests", testCount)

--- a/cryptoaead/crypto_aead_aes256gcm_test.go
+++ b/cryptoaead/crypto_aead_aes256gcm_test.go
@@ -46,7 +46,7 @@ func TestCryptoAEADAES256GCM(t *testing.T) {
 		f.Fuzz(&test)
 
 		// Create a key context
-		ctx, err := CryptoAEADAES256CGMBeforeNM(test.Key[:])
+		ctx, err := CryptoAEADAES256GCMBeforeNM(test.Key[:])
 		if err != 0 {
 			t.Error("Context creation failed for %+v", test)
 		}

--- a/cryptoaead/crypto_aead_aes256gcm_test.go
+++ b/cryptoaead/crypto_aead_aes256gcm_test.go
@@ -1,0 +1,70 @@
+package cryptoaead
+
+import (
+	"testing"
+	"bytes"
+	"github.com/google/gofuzz"
+)
+
+var testCount = 1000000
+
+type Test struct {
+	Message    []byte
+	Ad         []byte
+	Key        [32]byte
+	Nonce      [12]byte
+}
+
+func TestCryptoAEADAES256GCM(t *testing.T) {
+	// Skip the test if unsupported on this platform
+	if !CryptoAEADAES256GCMIsAvailable() {
+		t.Skip()
+	}
+
+	// Test the key generation
+	if len(CryptoAEADAES256GCMKeyGen()) != CryptoAEADAES256GCMKeyBytes() {
+		t.Error("Generated key has the wrong length")
+	}
+
+	// Fuzzing
+	f := fuzz.New()
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var c, m, ec, mac []byte
+		var err int
+		var test Test
+
+		// Fuzz the test struct
+		f.Fuzz(&test)
+
+		// Detached encryption test
+		c, mac, err = CryptoAEADAES256GCMEncryptDetached(test.Message, test.Ad, test.Nonce[:], test.Key[:])
+		if err != 0 {
+			t.Errorf("Detached encryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Encryption test
+		ec, err = CryptoAEADAES256GCMEncrypt(test.Message, test.Ad, test.Nonce[:], test.Key[:])
+		if err != 0 || !bytes.Equal(ec, append(c, mac...)) {
+			t.Errorf("Encryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Detached decryption test
+		m, err = CryptoAEADAES256GCMDecryptDetached(c, mac, test.Ad, test.Nonce[:], test.Key[:])
+		if err != 0 || !bytes.Equal(m, test.Message) {
+			t.Errorf("Detached decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption test
+		m, err = CryptoAEADAES256GCMDecrypt(ec, test.Ad, test.Nonce[:], test.Key[:])
+		if err != 0 || !bytes.Equal(m, test.Message) {
+			t.Errorf("Decryption failed for %+v", test)
+			t.FailNow()
+		}
+	}
+	t.Logf("Completed %v tests", testCount)
+}

--- a/support/support.go
+++ b/support/support.go
@@ -13,8 +13,22 @@ func CheckSize(buf []byte, expected int, descrip string) {
 	}
 }
 
+func CheckSizeMin(buf []byte, min int, descrip string) {
+	if len(buf) < min {
+		panic(fmt.Sprintf("Incorrect %s buffer size, expected (>%d), got (%d).", descrip, min, len(buf)))
+	}
+}
+
 func CheckSizeInRange(size int, min int, max int, descrip string) {
 	if size < min || size > max {
 		panic(fmt.Sprintf("Incorrect %s buffer size, expected (%d - %d), got (%d).", descrip, min, max, size))
+	}
+}
+
+func BytePointer(b []byte) *uint8 {
+	if len(b) > 0 {
+		return &b[0]
+	} else {
+		return nil
 	}
 }


### PR DESCRIPTION
This pull requests extends the CryptoAEADAES256GCM functions and adds tests for the encryption and decryption as well.

For testing, I have used [google/gofuzz](https://github.com/google/gofuzz) for generating random data. This has as downside that the result of the detached encryption is not compared to a reference result (but the other functions are tested against it). An alternative is using the data that is used by libsodium, see [my other branch](/silkeh/libsodium-go/tree/crypto_aead_aes256gcm).