### PR TITLE
Fix/rename version and add comments and test

### DIFF
--- a/sodium/version.go
+++ b/sodium/version.go
@@ -5,18 +5,22 @@ package sodium
 // #include <sodium.h>
 import "C"
 
-func SodiumVersionString() string {
+// VersionString returns the libsodium version string
+func VersionString() string {
 	return C.GoString(C.sodium_version_string())
 }
 
-func SodiumLibaryVersionMajor() int {
+// LibraryVersionMajor returns the library major version number
+func LibraryVersionMajor() int {
 	return int(C.sodium_library_version_major())
 }
 
-func SodiumLibaryVersionMinor() int {
+// LibraryVersionMinor returns the library minor version number
+func LibraryVersionMinor() int {
 	return int(C.sodium_library_version_minor())
 }
 
-func SodiumLibaryMinimal() bool {
+// LibraryMinimal returns true for a minimal build
+func LibraryMinimal() bool {
 	return int(C.sodium_library_minimal()) != 0
 }

--- a/sodium/version_test.go
+++ b/sodium/version_test.go
@@ -1,0 +1,30 @@
+package sodium
+
+import (
+	"testing"
+	"strings"
+)
+
+func TestSodiumVersion(t *testing.T) {
+	str := VersionString()
+	maj := LibraryVersionMajor()
+	min := LibraryVersionMinor()
+	slm := LibraryMinimal()
+
+	t.Logf("Sodium version: %s\n", str)
+	t.Logf("Sodium library version: %v.%v", maj, min)
+	t.Logf("Minimal: %v", slm)
+
+	version := strings.Split(VersionString(), ".")
+	if len(version) != 3 {
+		t.Error("Sodium version should consist of three components")
+	}
+
+	if maj <= 0 || maj > 100 {
+		t.Errorf("Suspicious library version major: %v", maj)
+	}
+
+	if min <= 0 || min > 100 {
+		t.Errorf("Suspicious library version minor: %v", min)
+	}
+}


### PR DESCRIPTION
- Fix spelling error ('libary').
- Rename the functions to ones without stutter.
- Add comments and tests.