### PR TITLE
WIP: Crypto box

### DIFF
--- a/crypto/box/crypto_box.go
+++ b/crypto/box/crypto_box.go
@@ -19,21 +19,12 @@ const (
 	SealBytes      = C.crypto_box_SEALBYTES      // Overhead of a sealed encryption
 )
 
-// PublicKey represents a public key.
-type PublicKey [PublicKeyBytes]byte
-
-// SecretKey represents a secret (private) key.
-type SecretKey [SecretKeyBytes]byte
-
-// SharedKey represents a shared secret key generated from a public/secret key pair.
-type SharedKey [SharedKeyBytes]byte
-
 // GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_seed_keypair(
 		(*C.uchar)(&pk[0]),
@@ -44,9 +35,9 @@ func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
 }
 
 // GenerateKeys returns a keypair.
-func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_keypair(
 		(*C.uchar)(&pk[0]),
@@ -56,11 +47,11 @@ func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
 }
 
 // Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
-func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedKeyBytes]byte) {
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
-	k = new(SharedKey)
+	k = new([SharedKeyBytes]byte)
 
 	C.crypto_box_beforenm(
 		(*C.uchar)(&k[0]),
@@ -71,8 +62,8 @@ func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
 }
 
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns a ciphertext and a boolean indicating successful encryption.
-func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+// Returns a ciphertext.
+func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -91,8 +82,8 @@ func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
 }
 
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -116,8 +107,8 @@ func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
 }
 
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful encryption.
-func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+// Returns the encrypted message.
+func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
@@ -134,8 +125,8 @@ func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
 }
 
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -157,8 +148,8 @@ func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
 }
 
 // SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns a ciphertext, an authentication tag and a boolean indicating successful encryption.
-func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
+// Returns a ciphertext and an authentication tag.
+func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c, mac []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -179,8 +170,8 @@ func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
 }
 
 // OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSize(mac, MACBytes, "nonce")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -205,8 +196,8 @@ func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err
 }
 
 // SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful encryption.
-func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) {
+// Returns a ciphertext and an authentication tag.
+func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, mac []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
@@ -225,8 +216,8 @@ func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) 
 }
 
 // OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSize(mac, MACBytes, "nonce")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -249,8 +240,8 @@ func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, 
 }
 
 // SealAnonymous encrypts a message `m` for a public key `pk` without information about the sender.
-// Returns a ciphertext and a boolean indicating successful encryption.
-func SealAnonymous(m []byte, pk *PublicKey) (c []byte) {
+// Returns the encrypted message.
+func SealAnonymous(m []byte, pk *[PublicKeyBytes]byte) (c []byte) {
 	support.NilPanic(pk == nil, "public key")
 
 	c = make([]byte, len(m)+SealBytes)
@@ -265,8 +256,8 @@ func SealAnonymous(m []byte, pk *PublicKey) (c []byte) {
 }
 
 // OpenAnonymous decrypts a message `m` with public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenAnonymous(c []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenAnonymous(c []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, SealBytes, "ciphertext")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")

--- a/crypto/box/crypto_box.go
+++ b/crypto/box/crypto_box.go
@@ -1,4 +1,8 @@
 // Package box contains the libsodium bindings for public-key authenticated encryption.
+//
+// Note that the message length is not checked against MessageBytesMax,
+// as this is based on SODIUM_SIZE_MAX, which is the minimum of UINT64_MAX and SIZE_MAX.
+// Both can be expected to be higher than the maximum size of an integer and byte slice.
 package box
 
 // #cgo pkg-config: libsodium
@@ -9,14 +13,15 @@ import "github.com/GoKillers/libsodium-go/support"
 
 // Lengths of various arguments.
 const (
-	SeedBytes      = C.crypto_box_SEEDBYTES      // Required size of a keypair seed.
-	PublicKeyBytes = C.crypto_box_PUBLICKEYBYTES // Size of a public key.
-	SecretKeyBytes = C.crypto_box_SECRETKEYBYTES // Size of a secret key.
-	NonceBytes     = C.crypto_box_NONCEBYTES     // Size of a nonce.
-	MACBytes       = C.crypto_box_MACBYTES       // Size of an authentication tag.
-	Primitive      = C.crypto_box_PRIMITIVE      // Name of the algorithm used by crypto/box.
-	SharedKeyBytes = C.crypto_box_BEFORENMBYTES  // Size of a shared secret key.
-	SealBytes      = C.crypto_box_SEALBYTES      // Overhead of a sealed encryption
+	SeedBytes       = C.crypto_box_SEEDBYTES        // Required size of a keypair seed.
+	PublicKeyBytes  = C.crypto_box_PUBLICKEYBYTES   // Size of a public key.
+	SecretKeyBytes  = C.crypto_box_SECRETKEYBYTES   // Size of a secret key.
+	NonceBytes      = C.crypto_box_NONCEBYTES       // Size of a nonce.
+	MACBytes        = C.crypto_box_MACBYTES         // Size of an authentication tag.
+	Primitive       = C.crypto_box_PRIMITIVE        // Name of the algorithm used by crypto/box.
+	SharedKeyBytes  = C.crypto_box_BEFORENMBYTES    // Size of a shared secret key.
+	SealBytes       = C.crypto_box_SEALBYTES        // Overhead of a sealed encryption.
+	MessageBytesMax = C.crypto_box_MESSAGEBYTES_MAX // Maximum message size.
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.

--- a/crypto/box/crypto_box.go
+++ b/crypto/box/crypto_box.go
@@ -19,8 +19,8 @@ const (
 	SealBytes      = C.crypto_box_SEALBYTES      // Overhead of a sealed encryption
 )
 
-// GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKeyFromSeed returns a keypair generated from a given seed.
+func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
 	pk = new([PublicKeyBytes]byte)
@@ -34,8 +34,8 @@ func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKey
 	return
 }
 
-// GenerateKeys returns a keypair.
-func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKey returns a keypair.
+func GenerateKey() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
 

--- a/crypto/box/crypto_box.go
+++ b/crypto/box/crypto_box.go
@@ -1,0 +1,288 @@
+// Package box contains the libsodium bindings for public-key authenticated encryption.
+package box
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+// Lengths of various arguments.
+const (
+	SeedBytes      = C.crypto_box_SEEDBYTES      // Required size of a keypair seed.
+	PublicKeyBytes = C.crypto_box_PUBLICKEYBYTES // Size of a public key.
+	SecretKeyBytes = C.crypto_box_SECRETKEYBYTES // Size of a secret key.
+	NonceBytes     = C.crypto_box_NONCEBYTES     // Size of a nonce.
+	MACBytes       = C.crypto_box_MACBYTES       // Size of an authentication tag.
+	Primitive      = C.crypto_box_PRIMITIVE      // Name of the algorithm used by crypto/box.
+	SharedKeyBytes = C.crypto_box_BEFORENMBYTES  // Size of a shared secret key.
+	SealBytes      = C.crypto_box_SEALBYTES      // Overhead of a sealed encryption
+)
+
+// PublicKey represents a public key.
+type PublicKey [PublicKeyBytes]byte
+
+// SecretKey represents a secret (private) key.
+type SecretKey [SecretKeyBytes]byte
+
+// SharedKey represents a shared secret key generated from a public/secret key pair.
+type SharedKey [SharedKeyBytes]byte
+
+// GenerateKeysFromSeed returns a keypair generated from a given seed.
+func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+	support.CheckSize(seed, SeedBytes, "seed")
+
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_seed_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]),
+		(*C.uchar)(&seed[0]))
+
+	return
+}
+
+// GenerateKeys returns a keypair.
+func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
+func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	k = new(SharedKey)
+
+	C.crypto_box_beforenm(
+		(*C.uchar)(&k[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext and a boolean indicating successful encryption.
+func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+	support.NilPanic(n == nil, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m)+MACBytes)
+
+	C.crypto_box_easy(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSizeMin(c, MACBytes, "ciphertext")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c)-MACBytes)
+
+	exit := C.crypto_box_open_easy(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m)+MACBytes)
+
+	C.crypto_box_easy_afternm(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSizeMin(c, MACBytes, "ciphertext")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c)-MACBytes)
+
+	exit := C.crypto_box_open_easy_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext, an authentication tag and a boolean indicating successful encryption.
+func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m))
+	mac = make([]byte, MACBytes)
+
+	C.crypto_box_detached(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSize(mac, MACBytes, "nonce")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_open_detached(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m))
+	mac = make([]byte, MACBytes)
+
+	C.crypto_box_detached_afternm(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSize(mac, MACBytes, "nonce")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_open_detached_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealAnonymous encrypts a message `m` for a public key `pk` without information about the sender.
+// Returns a ciphertext and a boolean indicating successful encryption.
+func SealAnonymous(m []byte, pk *PublicKey) (c []byte) {
+	support.NilPanic(pk == nil, "public key")
+
+	c = make([]byte, len(m)+SealBytes)
+
+	C.crypto_box_seal(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&pk[0]))
+
+	return
+}
+
+// OpenAnonymous decrypts a message `m` with public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenAnonymous(c []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSizeMin(c, SealBytes, "ciphertext")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c)-SealBytes)
+
+	exit := C.crypto_box_seal_open(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}

--- a/crypto/box/crypto_box.go
+++ b/crypto/box/crypto_box.go
@@ -20,8 +20,8 @@ const (
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.
-func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
-	support.CheckSize(seed, SeedBytes, "seed")
+func GenerateKeyFromSeed(seed *[SeedBytes]byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	support.NilPanic(seed == nil, "seed")
 
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
@@ -63,7 +63,7 @@ func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedK
 
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns a ciphertext.
-func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
+func Seal(m []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -83,9 +83,9 @@ func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []
 
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
+func Open(c []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -108,8 +108,8 @@ func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []
 
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
 // Returns the encrypted message.
-func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealAfterPrecomputation(m []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (c []byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	c = make([]byte, len(m)+MACBytes)
@@ -126,9 +126,9 @@ func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
+func OpenAfterPrecomputation(c []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	m = make([]byte, len(c)-MACBytes)
@@ -149,13 +149,13 @@ func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, er
 
 // SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns a ciphertext and an authentication tag.
-func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c, mac []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealDetached(m []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte, mac *[MACBytes]byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
 	c = make([]byte, len(m))
-	mac = make([]byte, MACBytes)
+	mac = new([MACBytes]byte)
 
 	C.crypto_box_detached(
 		(*C.uchar)(support.BytePointer(c)),
@@ -171,9 +171,9 @@ func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byt
 
 // OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
-	support.CheckSize(mac, MACBytes, "nonce")
-	support.CheckSize(n, NonceBytes, "nonce")
+func OpenDetached(c []byte, mac *[MACBytes]byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
+	support.NilPanic(mac == nil, "mac")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -197,12 +197,12 @@ func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyByte
 
 // SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
 // Returns a ciphertext and an authentication tag.
-func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, mac []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealDetachedAfterPrecomputation(m []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (c []byte, mac *[MACBytes]byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	c = make([]byte, len(m))
-	mac = make([]byte, MACBytes)
+	mac = new([MACBytes]byte)
 
 	C.crypto_box_detached_afternm(
 		(*C.uchar)(support.BytePointer(c)),
@@ -217,9 +217,9 @@ func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, m
 
 // OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
-	support.CheckSize(mac, MACBytes, "nonce")
-	support.CheckSize(n, NonceBytes, "nonce")
+func OpenDetachedAfterPrecomputation(c []byte, mac *[MACBytes]byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
+	support.NilPanic(mac == nil, "mac")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	m = make([]byte, len(c))

--- a/crypto/box/crypto_box_compat.go
+++ b/crypto/box/crypto_box_compat.go
@@ -1,0 +1,105 @@
+package box
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+// Lengths of various arguments.
+const (
+	ZeroBytes    = C.crypto_box_ZEROBYTES    // Size of the zero padding of the message.
+	BoxZeroBytes = C.crypto_box_BOXZEROBYTES // Size of NaCl box / ciphertext
+)
+
+// NaClSealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+// Note: message `m` requires `ZeroBytes` of padding on the front.
+func NaClSealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+	support.CheckSizeMin(m, ZeroBytes, "message with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m))
+
+	C.crypto_box_afternm(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// NaClOpenAfterPrecomputation decrypts a cyphertext `c` using nonce `n` from a shared key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
+func NaClOpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_open_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// NaClSeal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext and a boolean indicating successful encryption.
+// Note: message `m` requires `ZeroBytes` of padding on the front.
+func NaClSeal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+	support.CheckSizeMin(m, ZeroBytes, "message with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m))
+
+	C.crypto_box(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// NaClOpen decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
+func NaClOpen(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_open(
+		(*C.uchar)(&m[0]),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}

--- a/crypto/box/crypto_box_compat.go
+++ b/crypto/box/crypto_box_compat.go
@@ -15,7 +15,7 @@ const (
 // NaClSealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared key `k`.
 // Returns the decrypted message and a boolean indicating successful encryption.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func NaClSealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+func NaClSealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -35,7 +35,7 @@ func NaClSealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
 // NaClOpenAfterPrecomputation decrypts a cyphertext `c` using nonce `n` from a shared key `k`.
 // Returns the decrypted message and a boolean indicating successful decryption and verification.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func NaClOpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+func NaClOpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -59,7 +59,7 @@ func NaClOpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error
 // NaClSeal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns a ciphertext and a boolean indicating successful encryption.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func NaClSeal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+func NaClSeal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -81,7 +81,7 @@ func NaClSeal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
 // NaClOpen decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and a boolean indicating successful decryption and verification.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func NaClOpen(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+func NaClOpen(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")

--- a/crypto/box/crypto_box_test.go
+++ b/crypto/box/crypto_box_test.go
@@ -29,8 +29,8 @@ func TestCryptoBox(t *testing.T) {
 
 	// Test if GenerateKeys creates a non-zero key
 	pk, sk := GenerateKeys()
-	zeroes := new([32]byte)
-	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+	zeroes := new([PublicKeyBytes]byte)
+	if *pk == *zeroes || *sk == *zeroes {
 		t.Error("GenerateKeys generated an all zero key.")
 	}
 

--- a/crypto/box/crypto_box_test.go
+++ b/crypto/box/crypto_box_test.go
@@ -1,0 +1,163 @@
+package box
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+var testCount = 5000
+
+type Test struct {
+	Message []byte
+	Nonce   [NonceBytes]byte
+	Seed    [SeedBytes]byte
+}
+
+func checkResult(fail bool, err error, a, b []byte) bool {
+	if fail {
+		return err == nil
+	}
+	return err != nil || !bytes.Equal(a, b)
+}
+
+func TestCryptoBox(t *testing.T) {
+	// Check primitive
+	if Primitive != "curve25519xsalsa20poly1305" {
+		t.Errorf("Unexpected primitive: %s", Primitive)
+	}
+
+	// Test if GenerateKeys creates a non-zero key
+	pk, sk := GenerateKeys()
+	zeroes := new([32]byte)
+	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+		t.Error("GenerateKeys generated an all zero key.")
+	}
+
+	// Fuzzing
+	f := fuzz.New().NumElements(1, 1024)
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var test Test
+		var err error
+		var testMac, ciphertext []byte
+		var fail bool
+
+		// Fuzz the test struct
+		f.Fuzz(&test)
+		f.Fuzz(&fail)
+
+		// Generate Keys
+		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+
+		// Generate shared key
+		shk := Precompute(pk, sk)
+
+		// Detached encryption test
+		ciphertext, testMac = SealDetached(test.Message, test.Nonce[:], pk, sk)
+
+		// Detached encryption after precomputation
+		c, mac := SealDetachedAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		if !bytes.Equal(c, ciphertext) || !bytes.Equal(mac, testMac) {
+			t.Errorf("Detached encryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Encryption
+		ec := Seal(test.Message, test.Nonce[:], pk, sk)
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("Encryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Encryption with shared key
+		ec = SealAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("Encryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// NaCl encryption
+		mPad := append(make([]byte, ZeroBytes), test.Message...)
+		ec = NaClSeal(mPad, test.Nonce[:], pk, sk)
+		ec = ec[BoxZeroBytes:]
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("NaCl encryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// NaCl encryption with shared key
+		ec = NaClSealAfterPrecomputation(mPad, test.Nonce[:], shk)
+		ec = ec[BoxZeroBytes:]
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("NaCl encryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Test with incorrect MAC
+		if fail {
+			mac = make([]byte, MACBytes)
+			copy(ec[len(ec)-MACBytes:], mac)
+		}
+
+		// Detached decryption test
+		m, err := OpenDetached(c, mac, test.Nonce[:], pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Detached decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Detached decryption with shared key test
+		m, err = OpenDetachedAfterPrecomputation(c, mac, test.Nonce[:], shk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Detached decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption test
+		m, err = Open(ec, test.Nonce[:], pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption with shared key test
+		m, err = OpenAfterPrecomputation(ec, test.Nonce[:], shk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// NaCl decryption test
+		ecPad := append(make([]byte, BoxZeroBytes), ec...)
+		m, err = NaClOpen(ecPad, test.Nonce[:], pk, sk)
+		m = m[ZeroBytes:]
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("NaCl decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// NaCl decryption with shared key test
+		m, err = NaClOpenAfterPrecomputation(ecPad, test.Nonce[:], shk)
+		m = m[ZeroBytes:]
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("NaCl decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Anonymous test
+		ec = SealAnonymous(test.Message, pk)
+
+		if fail {
+			copy(ec[len(ec)-MACBytes:], mac)
+		}
+
+		m, err = OpenAnonymous(ec, pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Anonymous decryption failed (%v) for c: %v, m: %v", err, ec, test.Message)
+			t.FailNow()
+		}
+	}
+	t.Logf("Completed %v tests", testCount)
+}

--- a/crypto/box/crypto_box_test.go
+++ b/crypto/box/crypto_box_test.go
@@ -27,11 +27,11 @@ func TestCryptoBox(t *testing.T) {
 		t.Errorf("Unexpected primitive: %s", Primitive)
 	}
 
-	// Test if GenerateKeys creates a non-zero key
-	pk, sk := GenerateKeys()
+	// Test if GenerateKey creates a non-zero key
+	pk, sk := GenerateKey()
 	zeroes := new([PublicKeyBytes]byte)
 	if *pk == *zeroes || *sk == *zeroes {
-		t.Error("GenerateKeys generated an all zero key.")
+		t.Error("GenerateKey generated an all zero key.")
 	}
 
 	// Fuzzing
@@ -49,7 +49,7 @@ func TestCryptoBox(t *testing.T) {
 		f.Fuzz(&fail)
 
 		// Generate Keys
-		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+		pk, sk = GenerateKeyFromSeed(test.Seed[:])
 
 		// Generate shared key
 		shk := Precompute(pk, sk)

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
@@ -1,0 +1,248 @@
+// Package curve25519xchacha20poly1305 contains the libsodium bindings
+// for public-key authenticated encryption using Curve25519-XChaCha20-Poly1305.
+package curve25519xchacha20poly1305
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+// Lengths of various arguments.
+const (
+	SeedBytes      = C.crypto_box_curve25519xchacha20poly1305_SEEDBYTES      // Required size of a keypair seed.
+	PublicKeyBytes = C.crypto_box_curve25519xchacha20poly1305_PUBLICKEYBYTES // Size of a public key.
+	SecretKeyBytes = C.crypto_box_curve25519xchacha20poly1305_SECRETKEYBYTES // Size of a secret key.
+	NonceBytes     = C.crypto_box_curve25519xchacha20poly1305_NONCEBYTES     // Size of a nonce.
+	MACBytes       = C.crypto_box_curve25519xchacha20poly1305_MACBYTES       // Size of an authentication tag.
+	SharedKeyBytes = C.crypto_box_curve25519xchacha20poly1305_BEFORENMBYTES  // Size of a shared secret key.
+)
+
+// PublicKey represents a public key.
+type PublicKey [PublicKeyBytes]byte
+
+// SecretKey represents a secret (private) key.
+type SecretKey [SecretKeyBytes]byte
+
+// SharedKey represents a shared secret key generated from a public/secret key pair.
+type SharedKey [SharedKeyBytes]byte
+
+// GenerateKeysFromSeed returns a keypair generated from a given seed.
+func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+	support.CheckSize(seed, SeedBytes, "seed")
+
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_curve25519xchacha20poly1305_seed_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]),
+		(*C.uchar)(&seed[0]))
+
+	return
+}
+
+// GenerateKeys returns a keypair.
+func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_curve25519xchacha20poly1305_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
+func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	k = new(SharedKey)
+
+	C.crypto_box_curve25519xchacha20poly1305_beforenm(
+		(*C.uchar)(&k[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext and a boolean indicating successful encryption.
+func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+	support.NilPanic(n == nil, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m)+MACBytes)
+
+	C.crypto_box_curve25519xchacha20poly1305_easy(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSizeMin(c, MACBytes, "ciphertext")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c)-MACBytes)
+
+	exit := C.crypto_box_curve25519xchacha20poly1305_open_easy(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m)+MACBytes)
+
+	C.crypto_box_curve25519xchacha20poly1305_easy_afternm(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSizeMin(c, MACBytes, "ciphertext")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c)-MACBytes)
+
+	exit := C.crypto_box_curve25519xchacha20poly1305_open_easy_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext, an authentication tag and a boolean indicating successful encryption.
+func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m))
+	mac = make([]byte, MACBytes)
+
+	C.crypto_box_curve25519xchacha20poly1305_detached(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSize(mac, MACBytes, "nonce")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_curve25519xchacha20poly1305_open_detached(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) {
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m))
+	mac = make([]byte, MACBytes)
+
+	C.crypto_box_curve25519xchacha20poly1305_detached_afternm(
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSize(mac, MACBytes, "nonce")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_curve25519xchacha20poly1305_open_detached_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(support.BytePointer(c)),
+		(*C.uchar)(&mac[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
@@ -19,8 +19,8 @@ const (
 	SealBytes      = C.crypto_box_curve25519xchacha20poly1305_SEALBYTES      // Overhead of a sealed encryption
 )
 
-// GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKeyFromSeed returns a keypair generated from a given seed.
+func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
 	pk = new([PublicKeyBytes]byte)
@@ -34,8 +34,8 @@ func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKey
 	return
 }
 
-// GenerateKeys returns a keypair.
-func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKey returns a keypair.
+func GenerateKey() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
 

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
@@ -20,8 +20,8 @@ const (
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.
-func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
-	support.CheckSize(seed, SeedBytes, "seed")
+func GenerateKeyFromSeed(seed *[SeedBytes]byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	support.NilPanic(seed == nil, "seed")
 
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
@@ -63,7 +63,7 @@ func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedK
 
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the encrypted message.
-func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
+func Seal(m []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -83,9 +83,9 @@ func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []
 
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
+func Open(c []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -108,8 +108,8 @@ func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []
 
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
 // Returns the encrypted message.
-func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealAfterPrecomputation(m []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (c []byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	c = make([]byte, len(m)+MACBytes)
@@ -126,9 +126,9 @@ func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
+func OpenAfterPrecomputation(c []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	m = make([]byte, len(c)-MACBytes)
@@ -149,13 +149,13 @@ func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, er
 
 // SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns a ciphertext and an authentication tag.
-func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c, mac []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealDetached(m []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte, mac *[MACBytes]byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
 	c = make([]byte, len(m))
-	mac = make([]byte, MACBytes)
+	mac = new([MACBytes]byte)
 
 	C.crypto_box_curve25519xchacha20poly1305_detached(
 		(*C.uchar)(support.BytePointer(c)),
@@ -171,9 +171,9 @@ func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byt
 
 // OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
-	support.CheckSize(mac, MACBytes, "nonce")
-	support.CheckSize(n, NonceBytes, "nonce")
+func OpenDetached(c []byte, mac *[MACBytes]byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
+	support.NilPanic(mac == nil, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -197,12 +197,12 @@ func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyByte
 
 // SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
 // Returns a ciphertext and an authentication tag.
-func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, mac []byte) {
-	support.CheckSize(n, NonceBytes, "nonce")
+func SealDetachedAfterPrecomputation(m []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (c []byte, mac *[MACBytes]byte) {
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	c = make([]byte, len(m))
-	mac = make([]byte, MACBytes)
+	mac = new([MACBytes]byte)
 
 	C.crypto_box_curve25519xchacha20poly1305_detached_afternm(
 		(*C.uchar)(support.BytePointer(c)),
@@ -217,9 +217,9 @@ func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, m
 
 // OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
-func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
-	support.CheckSize(mac, MACBytes, "nonce")
-	support.CheckSize(n, NonceBytes, "nonce")
+func OpenDetachedAfterPrecomputation(c []byte, mac *[MACBytes]byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
+	support.NilPanic(mac == nil, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	m = make([]byte, len(c))

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
@@ -1,5 +1,9 @@
 // Package curve25519xchacha20poly1305 contains the libsodium bindings
 // for public-key authenticated encryption using Curve25519-XChaCha20-Poly1305.
+//
+// Note that the message length is not checked against MessageBytesMax,
+// as this is based on SODIUM_SIZE_MAX, which is the minimum of UINT64_MAX and SIZE_MAX.
+// Both can be expected to be higher than the maximum size of an integer and byte slice.
 package curve25519xchacha20poly1305
 
 // #cgo pkg-config: libsodium
@@ -10,13 +14,14 @@ import "github.com/GoKillers/libsodium-go/support"
 
 // Lengths of various arguments.
 const (
-	SeedBytes      = C.crypto_box_curve25519xchacha20poly1305_SEEDBYTES      // Required size of a keypair seed.
-	PublicKeyBytes = C.crypto_box_curve25519xchacha20poly1305_PUBLICKEYBYTES // Size of a public key.
-	SecretKeyBytes = C.crypto_box_curve25519xchacha20poly1305_SECRETKEYBYTES // Size of a secret key.
-	NonceBytes     = C.crypto_box_curve25519xchacha20poly1305_NONCEBYTES     // Size of a nonce.
-	MACBytes       = C.crypto_box_curve25519xchacha20poly1305_MACBYTES       // Size of an authentication tag.
-	SharedKeyBytes = C.crypto_box_curve25519xchacha20poly1305_BEFORENMBYTES  // Size of a shared secret key.
-	SealBytes      = C.crypto_box_curve25519xchacha20poly1305_SEALBYTES      // Overhead of a sealed encryption
+	SeedBytes       = C.crypto_box_curve25519xchacha20poly1305_SEEDBYTES        // Required size of a keypair seed.
+	PublicKeyBytes  = C.crypto_box_curve25519xchacha20poly1305_PUBLICKEYBYTES   // Size of a public key.
+	SecretKeyBytes  = C.crypto_box_curve25519xchacha20poly1305_SECRETKEYBYTES   // Size of a secret key.
+	NonceBytes      = C.crypto_box_curve25519xchacha20poly1305_NONCEBYTES       // Size of a nonce.
+	MACBytes        = C.crypto_box_curve25519xchacha20poly1305_MACBYTES         // Size of an authentication tag.
+	SharedKeyBytes  = C.crypto_box_curve25519xchacha20poly1305_BEFORENMBYTES    // Size of a shared secret key.
+	SealBytes       = C.crypto_box_curve25519xchacha20poly1305_SEALBYTES        // Overhead of a sealed encryption
+	MessageBytesMax = C.crypto_box_curve25519xchacha20poly1305_MESSAGEBYTES_MAX // Maximum message size
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305.go
@@ -19,21 +19,12 @@ const (
 	SealBytes      = C.crypto_box_curve25519xchacha20poly1305_SEALBYTES      // Overhead of a sealed encryption
 )
 
-// PublicKey represents a public key.
-type PublicKey [PublicKeyBytes]byte
-
-// SecretKey represents a secret (private) key.
-type SecretKey [SecretKeyBytes]byte
-
-// SharedKey represents a shared secret key generated from a public/secret key pair.
-type SharedKey [SharedKeyBytes]byte
-
 // GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_curve25519xchacha20poly1305_seed_keypair(
 		(*C.uchar)(&pk[0]),
@@ -44,9 +35,9 @@ func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
 }
 
 // GenerateKeys returns a keypair.
-func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_curve25519xchacha20poly1305_keypair(
 		(*C.uchar)(&pk[0]),
@@ -56,11 +47,11 @@ func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
 }
 
 // Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
-func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedKeyBytes]byte) {
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
-	k = new(SharedKey)
+	k = new([SharedKeyBytes]byte)
 
 	C.crypto_box_curve25519xchacha20poly1305_beforenm(
 		(*C.uchar)(&k[0]),
@@ -71,8 +62,8 @@ func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
 }
 
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns a ciphertext and a boolean indicating successful encryption.
-func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+// Returns the encrypted message.
+func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -91,8 +82,8 @@ func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
 }
 
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -116,8 +107,8 @@ func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
 }
 
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful encryption.
-func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+// Returns the encrypted message.
+func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
@@ -134,8 +125,8 @@ func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
 }
 
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, MACBytes, "ciphertext")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -157,8 +148,8 @@ func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
 }
 
 // SealDetached encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns a ciphertext, an authentication tag and a boolean indicating successful encryption.
-func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
+// Returns a ciphertext and an authentication tag.
+func SealDetached(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c, mac []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
@@ -179,8 +170,8 @@ func SealDetached(m, n []byte, pk *PublicKey, sk *SecretKey) (c, mac []byte) {
 }
 
 // OpenDetached decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenDetached(c, mac, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSize(mac, MACBytes, "nonce")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -205,8 +196,8 @@ func OpenDetached(c, mac, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err
 }
 
 // SealDetachedAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful encryption.
-func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) {
+// Returns a ciphertext and an authentication tag.
+func SealDetachedAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c, mac []byte) {
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
@@ -225,8 +216,8 @@ func SealDetachedAfterPrecomputation(m, n []byte, k *SharedKey) (c, mac []byte) 
 }
 
 // OpenDetachedAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSize(mac, MACBytes, "nonce")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -249,8 +240,8 @@ func OpenDetachedAfterPrecomputation(c, mac, n []byte, k *SharedKey) (m []byte, 
 }
 
 // SealAnonymous encrypts a message `m` for a public key `pk` without information about the sender.
-// Returns a ciphertext and a boolean indicating successful encryption.
-func SealAnonymous(m []byte, pk *PublicKey) (c []byte) {
+// Returns the encrypted message.
+func SealAnonymous(m []byte, pk *[PublicKeyBytes]byte) (c []byte) {
 	support.NilPanic(pk == nil, "public key")
 
 	c = make([]byte, len(m)+SealBytes)
@@ -265,8 +256,8 @@ func SealAnonymous(m []byte, pk *PublicKey) (c []byte) {
 }
 
 // OpenAnonymous decrypts a message `m` with public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
-func OpenAnonymous(c []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+// Returns the decrypted message and an error indicating decryption or verification failure.
+func OpenAnonymous(c []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, SealBytes, "ciphertext")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
@@ -1,0 +1,111 @@
+package curve25519xchacha20poly1305
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+var testCount = 5000
+
+type Test struct {
+	Message []byte
+	Nonce   [NonceBytes]byte
+	Seed    [SeedBytes]byte
+}
+
+func checkResult(fail bool, err error, a, b []byte) bool {
+	if fail {
+		return err == nil
+	}
+	return err != nil || !bytes.Equal(a, b)
+}
+
+func TestCryptoBox(t *testing.T) {
+	// Test if GenerateKeys creates a non-zero key
+	pk, sk := GenerateKeys()
+	zeroes := new([32]byte)
+	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+		t.Error("GenerateKeys generated an all zero key.")
+	}
+
+	// Fuzzing
+	f := fuzz.New().NumElements(1, 1024)
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var test Test
+		var err error
+		var testMac, ciphertext []byte
+		var fail bool
+
+		// Fuzz the test struct
+		f.Fuzz(&test)
+		f.Fuzz(&fail)
+
+		// Generate Keys
+		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+
+		// Generate shared key
+		shk := Precompute(pk, sk)
+
+		// Detached encryption test
+		ciphertext, testMac = SealDetached(test.Message, test.Nonce[:], pk, sk)
+
+		// Detached encryption after precomputation
+		c, mac := SealDetachedAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		if !bytes.Equal(c, ciphertext) || !bytes.Equal(mac, testMac) {
+			t.Errorf("Detached encryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Encryption
+		ec := Seal(test.Message, test.Nonce[:], pk, sk)
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("Encryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Encryption with shared key
+		ec = SealAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+			t.Errorf("Encryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Test with incorrect MAC
+		if fail {
+			mac = make([]byte, MACBytes)
+			copy(ec[len(ec)-MACBytes:], mac)
+		}
+
+		// Detached decryption test
+		m, err := OpenDetached(c, mac, test.Nonce[:], pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Detached decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Detached decryption with shared key test
+		m, err = OpenDetachedAfterPrecomputation(c, mac, test.Nonce[:], shk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Detached decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption test
+		m, err = Open(ec, test.Nonce[:], pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption with shared key test
+		m, err = OpenAfterPrecomputation(ec, test.Nonce[:], shk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+	}
+	t.Logf("Completed %v tests", testCount)
+}

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
@@ -106,6 +106,19 @@ func TestCryptoBox(t *testing.T) {
 			t.Errorf("Decryption with shared key failed for %+v", test)
 			t.FailNow()
 		}
+
+		// Anonymous test
+		ec = SealAnonymous(test.Message, pk)
+
+		if fail {
+			copy(ec[len(ec)-MACBytes:], mac)
+		}
+
+		m, err = OpenAnonymous(ec, pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Anonymous decryption failed (%v) for c: %v, m: %v", err, ec, test.Message)
+			t.FailNow()
+		}
 	}
 	t.Logf("Completed %v tests", testCount)
 }

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
@@ -22,11 +22,11 @@ func checkResult(fail bool, err error, a, b []byte) bool {
 }
 
 func TestCryptoBox(t *testing.T) {
-	// Test if GenerateKeys creates a non-zero key
-	pk, sk := GenerateKeys()
+	// Test if GenerateKey creates a non-zero key
+	pk, sk := GenerateKey()
 	zeroes := new([PublicKeyBytes]byte)
 	if *pk == *zeroes || *sk == *zeroes {
-		t.Error("GenerateKeys generated an all zero key.")
+		t.Error("GenerateKey generated an all zero key.")
 	}
 
 	// Fuzzing
@@ -44,7 +44,7 @@ func TestCryptoBox(t *testing.T) {
 		f.Fuzz(&fail)
 
 		// Generate Keys
-		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+		pk, sk = GenerateKeyFromSeed(test.Seed[:])
 
 		// Generate shared key
 		shk := Precompute(pk, sk)

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
@@ -24,8 +24,8 @@ func checkResult(fail bool, err error, a, b []byte) bool {
 func TestCryptoBox(t *testing.T) {
 	// Test if GenerateKeys creates a non-zero key
 	pk, sk := GenerateKeys()
-	zeroes := new([32]byte)
-	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+	zeroes := new([PublicKeyBytes]byte)
+	if *pk == *zeroes || *sk == *zeroes {
 		t.Error("GenerateKeys generated an all zero key.")
 	}
 

--- a/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
+++ b/crypto/box/curve25519xchacha20poly1305/crypto_box_curve25519xchacha20poly1305_test.go
@@ -36,7 +36,6 @@ func TestCryptoBox(t *testing.T) {
 	for i := 0; i < testCount; i++ {
 		var test Test
 		var err error
-		var testMac, ciphertext []byte
 		var fail bool
 
 		// Fuzz the test struct
@@ -44,64 +43,64 @@ func TestCryptoBox(t *testing.T) {
 		f.Fuzz(&fail)
 
 		// Generate Keys
-		pk, sk = GenerateKeyFromSeed(test.Seed[:])
+		pk, sk = GenerateKeyFromSeed(&test.Seed)
 
 		// Generate shared key
 		shk := Precompute(pk, sk)
 
 		// Detached encryption test
-		ciphertext, testMac = SealDetached(test.Message, test.Nonce[:], pk, sk)
+		ciphertext, testMac := SealDetached(test.Message, &test.Nonce, pk, sk)
 
 		// Detached encryption after precomputation
-		c, mac := SealDetachedAfterPrecomputation(test.Message, test.Nonce[:], shk)
-		if !bytes.Equal(c, ciphertext) || !bytes.Equal(mac, testMac) {
+		c, mac := SealDetachedAfterPrecomputation(test.Message, &test.Nonce, shk)
+		if !bytes.Equal(c, ciphertext) || !bytes.Equal(mac[:], testMac[:]) {
 			t.Errorf("Detached encryption with shared key failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Encryption
-		ec := Seal(test.Message, test.Nonce[:], pk, sk)
-		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+		ec := Seal(test.Message, &test.Nonce, pk, sk)
+		if !bytes.Equal(ec, append(testMac[:], ciphertext...)) {
 			t.Errorf("Encryption failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Encryption with shared key
-		ec = SealAfterPrecomputation(test.Message, test.Nonce[:], shk)
-		if !bytes.Equal(ec, append(testMac, ciphertext...)) {
+		ec = SealAfterPrecomputation(test.Message, &test.Nonce, shk)
+		if !bytes.Equal(ec, append(testMac[:], ciphertext...)) {
 			t.Errorf("Encryption with shared key failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Test with incorrect MAC
 		if fail {
-			mac = make([]byte, MACBytes)
-			copy(ec[len(ec)-MACBytes:], mac)
+			mac = new([MACBytes]byte)
+			copy(ec[len(ec)-MACBytes:], mac[:])
 		}
 
 		// Detached decryption test
-		m, err := OpenDetached(c, mac, test.Nonce[:], pk, sk)
+		m, err := OpenDetached(c, mac, &test.Nonce, pk, sk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Detached decryption failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Detached decryption with shared key test
-		m, err = OpenDetachedAfterPrecomputation(c, mac, test.Nonce[:], shk)
+		m, err = OpenDetachedAfterPrecomputation(c, mac, &test.Nonce, shk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Detached decryption with shared key failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Decryption test
-		m, err = Open(ec, test.Nonce[:], pk, sk)
+		m, err = Open(ec, &test.Nonce, pk, sk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Decryption failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Decryption with shared key test
-		m, err = OpenAfterPrecomputation(ec, test.Nonce[:], shk)
+		m, err = OpenAfterPrecomputation(ec, &test.Nonce, shk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Decryption with shared key failed for %+v", test)
 			t.FailNow()
@@ -111,7 +110,7 @@ func TestCryptoBox(t *testing.T) {
 		ec = SealAnonymous(test.Message, pk)
 
 		if fail {
-			copy(ec[len(ec)-MACBytes:], mac)
+			copy(ec[len(ec)-MACBytes:], mac[:])
 		}
 
 		m, err = OpenAnonymous(ec, pk, sk)

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
@@ -21,8 +21,8 @@ const (
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.
-func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
-	support.CheckSize(seed, SeedBytes, "seed")
+func GenerateKeyFromSeed(seed *[SeedBytes]byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	support.NilPanic(seed == nil, "seed")
 
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
@@ -65,9 +65,9 @@ func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedK
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the encrypted message.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
+func Seal(m []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -87,9 +87,9 @@ func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
+func Open(c []byte, n *[NonceBytes]byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
@@ -113,9 +113,9 @@ func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
 // Returns the encrypted message.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
+func SealAfterPrecomputation(m []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	c = make([]byte, len(m))
@@ -133,9 +133,9 @@ func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
 // Returns the decrypted message and an error indicating decryption or verification failure.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
+func OpenAfterPrecomputation(c []byte, n *[NonceBytes]byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
-	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(n == nil, "nonce")
 	support.NilPanic(k == nil, "shared key")
 
 	m = make([]byte, len(c))

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
@@ -1,5 +1,9 @@
 // Package curve25519xsalsa20poly1305 contains the libsodium bindings
 // for public-key authenticated encryption using Curve25519-XSalsa20-Poly1305.
+//
+// Note that the message length is not checked against MessageBytesMax,
+// as this is based on SODIUM_SIZE_MAX, which is the minimum of UINT64_MAX and SIZE_MAX.
+// Both can be expected to be higher than the maximum size of an integer and byte slice.
 package curve25519xsalsa20poly1305
 
 // #cgo pkg-config: libsodium
@@ -10,14 +14,15 @@ import "github.com/GoKillers/libsodium-go/support"
 
 // Lengths of various arguments.
 const (
-	SeedBytes      = C.crypto_box_curve25519xsalsa20poly1305_SEEDBYTES      // Required size of a keypair seed.
-	PublicKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES // Size of a public key.
-	SecretKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES // Size of a secret key.
-	NonceBytes     = C.crypto_box_curve25519xsalsa20poly1305_NONCEBYTES     // Size of a nonce.
-	MACBytes       = C.crypto_box_curve25519xsalsa20poly1305_MACBYTES       // Size of an authentication tag.
-	SharedKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_BEFORENMBYTES  // Size of a shared secret key.
-	ZeroBytes      = C.crypto_box_ZEROBYTES                                 // Size of the zero padding of the message.
-	BoxZeroBytes   = C.crypto_box_BOXZEROBYTES                              // Size of NaCl box / ciphertext
+	SeedBytes       = C.crypto_box_curve25519xsalsa20poly1305_SEEDBYTES        // Required size of a keypair seed.
+	PublicKeyBytes  = C.crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES   // Size of a public key.
+	SecretKeyBytes  = C.crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES   // Size of a secret key.
+	NonceBytes      = C.crypto_box_curve25519xsalsa20poly1305_NONCEBYTES       // Size of a nonce.
+	MACBytes        = C.crypto_box_curve25519xsalsa20poly1305_MACBYTES         // Size of an authentication tag.
+	SharedKeyBytes  = C.crypto_box_curve25519xsalsa20poly1305_BEFORENMBYTES    // Size of a shared secret key.
+	MessageBytesMax = C.crypto_box_curve25519xsalsa20poly1305_MESSAGEBYTES_MAX // Maximum message size
+	ZeroBytes       = C.crypto_box_ZEROBYTES                                   // Size of the zero padding of the message.
+	BoxZeroBytes    = C.crypto_box_BOXZEROBYTES                                // Size of NaCl box / ciphertext
 )
 
 // GenerateKeyFromSeed returns a keypair generated from a given seed.

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
@@ -20,21 +20,12 @@ const (
 	BoxZeroBytes   = C.crypto_box_BOXZEROBYTES                              // Size of NaCl box / ciphertext
 )
 
-// PublicKey represents a public key.
-type PublicKey [PublicKeyBytes]byte
-
-// SecretKey represents a secret (private) key.
-type SecretKey [SecretKeyBytes]byte
-
-// SharedKey represents a shared secret key generated from a public/secret key pair.
-type SharedKey [SharedKeyBytes]byte
-
 // GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_curve25519xsalsa20poly1305_seed_keypair(
 		(*C.uchar)(&pk[0]),
@@ -45,9 +36,9 @@ func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
 }
 
 // GenerateKeys returns a keypair.
-func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
-	pk = new(PublicKey)
-	sk = new(SecretKey)
+func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+	pk = new([PublicKeyBytes]byte)
+	sk = new([SecretKeyBytes]byte)
 
 	C.crypto_box_curve25519xsalsa20poly1305_keypair(
 		(*C.uchar)(&pk[0]),
@@ -57,11 +48,11 @@ func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
 }
 
 // Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
-func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+func Precompute(pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (k *[SharedKeyBytes]byte) {
 	support.NilPanic(pk == nil, "public key")
 	support.NilPanic(sk == nil, "secret key")
 
-	k = new(SharedKey)
+	k = new([SharedKeyBytes]byte)
 
 	C.crypto_box_curve25519xsalsa20poly1305_beforenm(
 		(*C.uchar)(&k[0]),
@@ -72,9 +63,9 @@ func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
 }
 
 // Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns a ciphertext and a boolean indicating successful encryption.
+// Returns the encrypted message.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+func Seal(m, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -94,9 +85,9 @@ func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
 }
 
 // Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Returns the decrypted message and an error indicating decryption or verification failure.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+func Open(c, n []byte, pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(pk == nil, "public key")
@@ -120,9 +111,9 @@ func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
 }
 
 // SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful encryption.
+// Returns the encrypted message.
 // Note: message `m` requires `ZeroBytes` of padding on the front.
-func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+func SealAfterPrecomputation(m, n []byte, k *[SharedKeyBytes]byte) (c []byte) {
 	support.CheckSizeMin(m, ZeroBytes, "message with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")
@@ -140,9 +131,9 @@ func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
 }
 
 // OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
-// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Returns the decrypted message and an error indicating decryption or verification failure.
 // Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
-func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+func OpenAfterPrecomputation(c, n []byte, k *[SharedKeyBytes]byte) (m []byte, err error) {
 	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
 	support.CheckSize(n, NonceBytes, "nonce")
 	support.NilPanic(k == nil, "shared key")

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
@@ -1,0 +1,164 @@
+// Package curve25519xsalsa20poly1305 contains the libsodium bindings
+// for public-key authenticated encryption using Curve25519-XSalsa20-Poly1305.
+package curve25519xsalsa20poly1305
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+// Lengths of various arguments.
+const (
+	SeedBytes      = C.crypto_box_curve25519xsalsa20poly1305_SEEDBYTES      // Required size of a keypair seed.
+	PublicKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES // Size of a public key.
+	SecretKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES // Size of a secret key.
+	NonceBytes     = C.crypto_box_curve25519xsalsa20poly1305_NONCEBYTES     // Size of a nonce.
+	MACBytes       = C.crypto_box_curve25519xsalsa20poly1305_MACBYTES       // Size of an authentication tag.
+	SharedKeyBytes = C.crypto_box_curve25519xsalsa20poly1305_BEFORENMBYTES  // Size of a shared secret key.
+	ZeroBytes      = C.crypto_box_ZEROBYTES                                 // Size of the zero padding of the message.
+	BoxZeroBytes   = C.crypto_box_BOXZEROBYTES                              // Size of NaCl box / ciphertext
+)
+
+// PublicKey represents a public key.
+type PublicKey [PublicKeyBytes]byte
+
+// SecretKey represents a secret (private) key.
+type SecretKey [SecretKeyBytes]byte
+
+// SharedKey represents a shared secret key generated from a public/secret key pair.
+type SharedKey [SharedKeyBytes]byte
+
+// GenerateKeysFromSeed returns a keypair generated from a given seed.
+func GenerateKeysFromSeed(seed []byte) (pk *PublicKey, sk *SecretKey) {
+	support.CheckSize(seed, SeedBytes, "seed")
+
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_curve25519xsalsa20poly1305_seed_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]),
+		(*C.uchar)(&seed[0]))
+
+	return
+}
+
+// GenerateKeys returns a keypair.
+func GenerateKeys() (pk *PublicKey, sk *SecretKey) {
+	pk = new(PublicKey)
+	sk = new(SecretKey)
+
+	C.crypto_box_curve25519xsalsa20poly1305_keypair(
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Precompute generates a shared key from a recipients public key `pk` and a sender's secret key `sk`.
+func Precompute(pk *PublicKey, sk *SecretKey) (k *SharedKey) {
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	k = new(SharedKey)
+
+	C.crypto_box_curve25519xsalsa20poly1305_beforenm(
+		(*C.uchar)(&k[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Seal encrypts a message `m` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns a ciphertext and a boolean indicating successful encryption.
+// Note: message `m` requires `ZeroBytes` of padding on the front.
+func Seal(m, n []byte, pk *PublicKey, sk *SecretKey) (c []byte) {
+	support.CheckSizeMin(m, ZeroBytes, "message with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	c = make([]byte, len(m))
+
+	C.crypto_box_curve25519xsalsa20poly1305(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(&m[0]),
+		C.ulonglong(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	return
+}
+
+// Open decrypts a ciphertext `c` using nonce `n`, public key `pk` and secret key `sk`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
+func Open(c, n []byte, pk *PublicKey, sk *SecretKey) (m []byte, err error) {
+	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(pk == nil, "public key")
+	support.NilPanic(sk == nil, "secret key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_curve25519xsalsa20poly1305_open(
+		(*C.uchar)(&m[0]),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&pk[0]),
+		(*C.uchar)(&sk[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}
+
+// SealAfterPrecomputation encrypts a message `m` with nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful encryption.
+// Note: message `m` requires `ZeroBytes` of padding on the front.
+func SealAfterPrecomputation(m, n []byte, k *SharedKey) (c []byte) {
+	support.CheckSizeMin(m, ZeroBytes, "message with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	c = make([]byte, len(m))
+
+	C.crypto_box_curve25519xsalsa20poly1305_afternm(
+		(*C.uchar)(&c[0]),
+		(*C.uchar)(support.BytePointer(m)),
+		(C.ulonglong)(len(m)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	return
+}
+
+// OpenAfterPrecomputation decrypts a ciphertext `c` using nonce `n` from a shared secret key `k`.
+// Returns the decrypted message and a boolean indicating successful decryption and verification.
+// Note: ciphertext `c` requires `BoxZeroBytes` padding on the front.
+func OpenAfterPrecomputation(c, n []byte, k *SharedKey) (m []byte, err error) {
+	support.CheckSizeMin(c, ZeroBytes, "ciphertext with padding")
+	support.CheckSize(n, NonceBytes, "nonce")
+	support.NilPanic(k == nil, "shared key")
+
+	m = make([]byte, len(c))
+
+	exit := C.crypto_box_curve25519xsalsa20poly1305_open_afternm(
+		(*C.uchar)(support.BytePointer(m)),
+		(*C.uchar)(&c[0]),
+		(C.ulonglong)(len(c)),
+		(*C.uchar)(&n[0]),
+		(*C.uchar)(&k[0]))
+
+	if exit != 0 {
+		err = &support.VerificationError{}
+	}
+
+	return
+}

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305.go
@@ -20,8 +20,8 @@ const (
 	BoxZeroBytes   = C.crypto_box_BOXZEROBYTES                              // Size of NaCl box / ciphertext
 )
 
-// GenerateKeysFromSeed returns a keypair generated from a given seed.
-func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKeyFromSeed returns a keypair generated from a given seed.
+func GenerateKeyFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	support.CheckSize(seed, SeedBytes, "seed")
 
 	pk = new([PublicKeyBytes]byte)
@@ -35,8 +35,8 @@ func GenerateKeysFromSeed(seed []byte) (pk *[PublicKeyBytes]byte, sk *[SecretKey
 	return
 }
 
-// GenerateKeys returns a keypair.
-func GenerateKeys() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
+// GenerateKey returns a keypair.
+func GenerateKey() (pk *[PublicKeyBytes]byte, sk *[SecretKeyBytes]byte) {
 	pk = new([PublicKeyBytes]byte)
 	sk = new([SecretKeyBytes]byte)
 

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
@@ -1,0 +1,85 @@
+package curve25519xsalsa20poly1305
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+var testCount = 5000
+
+type Test struct {
+	Message []byte
+	Nonce   [NonceBytes]byte
+	Seed    [SeedBytes]byte
+}
+
+func checkResult(fail bool, err error, a, b []byte) bool {
+	if fail {
+		return err == nil
+	}
+	return err != nil || !bytes.Equal(a, b)
+}
+
+func TestCryptoBoxSalsa(t *testing.T) {
+	// Test if GenerateKeysFromSeed
+	pk, sk := GenerateKeys()
+	zeroes := new([32]byte)
+	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+		t.Error("GenerateKeys generated an all zero key.")
+	}
+
+	// Fuzzing
+	f := fuzz.New().NumElements(1, 1024)
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var test Test
+		var err error
+		var m, ciphertext []byte
+		var fail bool
+
+		// Fuzz the test struct
+		f.Fuzz(&test)
+		f.Fuzz(&fail)
+
+		// Provide the required padding
+		test.Message = append(make([]byte, ZeroBytes), test.Message...)
+
+		// Generate Keys
+		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+
+		// Generate shared key
+		shk := Precompute(pk, sk)
+
+		// Encryption
+		ciphertext = Seal(test.Message, test.Nonce[:], pk, sk)
+
+		// Encryption with context
+		ec := SealAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		if !bytes.Equal(ec, ciphertext) {
+			t.Errorf("Encryption with shared key failed for %+v:", test)
+			t.FailNow()
+		}
+
+		// Test with incorrect MAC
+		if fail {
+			copy(ec[len(ec)-MACBytes:], make([]byte, MACBytes))
+		}
+
+		// Decryption test
+		m, err = Open(ec, test.Nonce[:], pk, sk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption failed for %+v", test)
+			t.FailNow()
+		}
+
+		// Decryption with shared key test
+		m, err = OpenAfterPrecomputation(ec, test.Nonce[:], shk)
+		if checkResult(fail, err, m, test.Message) {
+			t.Errorf("Decryption with shared key failed for %+v", test)
+			t.FailNow()
+		}
+	}
+	t.Logf("Completed %v tests", testCount)
+}

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
@@ -22,11 +22,11 @@ func checkResult(fail bool, err error, a, b []byte) bool {
 }
 
 func TestCryptoBoxSalsa(t *testing.T) {
-	// Test if GenerateKeysFromSeed
-	pk, sk := GenerateKeys()
+	// Test if GenerateKeyFromSeed
+	pk, sk := GenerateKey()
 	zeroes := new([PublicKeyBytes]byte)
 	if *pk == *zeroes || *sk == *zeroes {
-		t.Error("GenerateKeys generated an all zero key.")
+		t.Error("GenerateKey generated an all zero key.")
 	}
 
 	// Fuzzing
@@ -47,7 +47,7 @@ func TestCryptoBoxSalsa(t *testing.T) {
 		test.Message = append(make([]byte, ZeroBytes), test.Message...)
 
 		// Generate Keys
-		pk, sk = GenerateKeysFromSeed(test.Seed[:])
+		pk, sk = GenerateKeyFromSeed(test.Seed[:])
 
 		// Generate shared key
 		shk := Precompute(pk, sk)

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
@@ -24,8 +24,8 @@ func checkResult(fail bool, err error, a, b []byte) bool {
 func TestCryptoBoxSalsa(t *testing.T) {
 	// Test if GenerateKeysFromSeed
 	pk, sk := GenerateKeys()
-	zeroes := new([32]byte)
-	if *pk == PublicKey(*zeroes) || *sk == SecretKey(*zeroes) {
+	zeroes := new([PublicKeyBytes]byte)
+	if *pk == *zeroes || *sk == *zeroes {
 		t.Error("GenerateKeys generated an all zero key.")
 	}
 

--- a/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
+++ b/crypto/box/curve25519xsalsa20poly1305/crypto_box_curve25519xsalsa20poly1305_test.go
@@ -47,16 +47,16 @@ func TestCryptoBoxSalsa(t *testing.T) {
 		test.Message = append(make([]byte, ZeroBytes), test.Message...)
 
 		// Generate Keys
-		pk, sk = GenerateKeyFromSeed(test.Seed[:])
+		pk, sk = GenerateKeyFromSeed(&test.Seed)
 
 		// Generate shared key
 		shk := Precompute(pk, sk)
 
 		// Encryption
-		ciphertext = Seal(test.Message, test.Nonce[:], pk, sk)
+		ciphertext = Seal(test.Message, &test.Nonce, pk, sk)
 
 		// Encryption with context
-		ec := SealAfterPrecomputation(test.Message, test.Nonce[:], shk)
+		ec := SealAfterPrecomputation(test.Message, &test.Nonce, shk)
 		if !bytes.Equal(ec, ciphertext) {
 			t.Errorf("Encryption with shared key failed for %+v:", test)
 			t.FailNow()
@@ -68,14 +68,14 @@ func TestCryptoBoxSalsa(t *testing.T) {
 		}
 
 		// Decryption test
-		m, err = Open(ec, test.Nonce[:], pk, sk)
+		m, err = Open(ec, &test.Nonce, pk, sk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Decryption failed for %+v", test)
 			t.FailNow()
 		}
 
 		// Decryption with shared key test
-		m, err = OpenAfterPrecomputation(ec, test.Nonce[:], shk)
+		m, err = OpenAfterPrecomputation(ec, &test.Nonce, shk)
 		if checkResult(fail, err, m, test.Message) {
 			t.Errorf("Decryption with shared key failed for %+v", test)
 			t.FailNow()


### PR DESCRIPTION
This PR adds a new wrapping of `crypto_box` (for libsodium 1.0.15)
The `crypto_box` functions are split into:

- `crypto/box`
- `crypto/box/curve25519xchacha20poly1305`
- `crypto/box/curve25519xsalsa20poly1305`

All code includes tests with 100% coverage and is linted with `golint`.