### PR TITLE
Update crypto/aead to libsodium 1.0.15

### DIFF
--- a/crypto/aead/aes256gcm/crypto_aead_aes256gcm.go
+++ b/crypto/aead/aes256gcm/crypto_aead_aes256gcm.go
@@ -14,10 +14,11 @@ func init() {
 
 // Sizes of nonces, key and mac.
 const (
-	KeyBytes   int = C.crypto_aead_aes256gcm_KEYBYTES  // Size of a secret key in bytes
-	NSecBytes  int = C.crypto_aead_aes256gcm_NSECBYTES // Size of a secret nonce in bytes
-	NonceBytes int = C.crypto_aead_aes256gcm_NPUBBYTES // Size of a nonce in bytes
-	ABytes     int = C.crypto_aead_aes256gcm_ABYTES    // Size of an authentication tag in bytes
+	KeyBytes        = C.crypto_aead_aes256gcm_KEYBYTES         // Size of a secret key in bytes
+	NSecBytes       = C.crypto_aead_aes256gcm_NSECBYTES        // Size of a secret nonce in bytes
+	NonceBytes      = C.crypto_aead_aes256gcm_NPUBBYTES        // Size of a nonce in bytes
+	ABytes          = C.crypto_aead_aes256gcm_ABYTES           // Size of an authentication tag in bytes
+	MessageBytesMax = C.crypto_aead_aes256gcm_MESSAGEBYTES_MAX // Maximum size of a message
 )
 
 // IsAvailable returns true if AES256 is available on the current CPU
@@ -35,6 +36,7 @@ func GenerateKey() *[KeyBytes]byte {
 // Encrypt a message `m` with additional data `ad` using a nonce `npub` and a secret key `k`.
 // A ciphertext (including authentication tag) and encryption status are returned.
 func Encrypt(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 
@@ -85,6 +87,7 @@ func Decrypt(c, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (m []byte
 // a nonce `npub` and a secret key `k`.
 // A ciphertext, authentication tag and encryption status are returned.
 func EncryptDetached(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c, mac []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 

--- a/crypto/aead/chacha20poly1305/crypto_aead_chacha20poly1305.go
+++ b/crypto/aead/chacha20poly1305/crypto_aead_chacha20poly1305.go
@@ -14,10 +14,11 @@ func init() {
 
 // Sizes of nonces, key and mac.
 const (
-	KeyBytes   int = C.crypto_aead_chacha20poly1305_KEYBYTES  // Size of a secret key in bytes
-	NSecBytes  int = C.crypto_aead_chacha20poly1305_NSECBYTES // Size of a secret nonce in bytes
-	NonceBytes int = C.crypto_aead_chacha20poly1305_NPUBBYTES // Size of a nonce in bytes
-	ABytes     int = C.crypto_aead_chacha20poly1305_ABYTES    // Size of an authentication tag in bytes
+	KeyBytes        = C.crypto_aead_chacha20poly1305_KEYBYTES         // Size of a secret key in bytes
+	NSecBytes       = C.crypto_aead_chacha20poly1305_NSECBYTES        // Size of a secret nonce in bytes
+	NonceBytes      = C.crypto_aead_chacha20poly1305_NPUBBYTES        // Size of a nonce in bytes
+	ABytes          = C.crypto_aead_chacha20poly1305_ABYTES           // Size of an authentication tag in bytes
+	MessageBytesMax = C.crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX // Maximum size of a message
 )
 
 // GenerateKey generates a secret key
@@ -30,6 +31,7 @@ func GenerateKey() *[KeyBytes]byte {
 // Encrypt a message `m` with additional data `ad` using a nonce `npub` and a secret key `k`.
 // A ciphertext (including authentication tag) and encryption status are returned.
 func Encrypt(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 
@@ -80,6 +82,7 @@ func Decrypt(c, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (m []byte
 // a nonce `npub` and a secret key `k`.
 // A ciphertext, authentication tag and encryption status are returned.
 func EncryptDetached(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c, mac []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 

--- a/crypto/aead/chacha20poly1305ietf/crypto_aead_chacha20poly1305_ietf.go
+++ b/crypto/aead/chacha20poly1305ietf/crypto_aead_chacha20poly1305_ietf.go
@@ -14,10 +14,11 @@ func init() {
 
 // Sizes of nonces, key and mac.
 const (
-	KeyBytes   int = C.crypto_aead_chacha20poly1305_ietf_KEYBYTES  // Size of a secret key in bytes
-	NSecBytes  int = C.crypto_aead_chacha20poly1305_ietf_NSECBYTES // Size of a secret nonce in bytes
-	NonceBytes int = C.crypto_aead_chacha20poly1305_ietf_NPUBBYTES // Size of a nonce in bytes
-	ABytes     int = C.crypto_aead_chacha20poly1305_ietf_ABYTES    // Size of an authentication tag in bytes
+	KeyBytes        = C.crypto_aead_chacha20poly1305_ietf_KEYBYTES    // Size of a secret key in bytes
+	NSecBytes       = C.crypto_aead_chacha20poly1305_ietf_NSECBYTES   // Size of a secret nonce in bytes
+	NonceBytes      = C.crypto_aead_chacha20poly1305_ietf_NPUBBYTES   // Size of a nonce in bytes
+	ABytes          = C.crypto_aead_chacha20poly1305_ietf_ABYTES      // Size of an authentication tag in bytes
+	MessageBytesMax = C.crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX // Maximum size of a message
 )
 
 // GenerateKey generates a secret key
@@ -30,6 +31,7 @@ func GenerateKey() *[KeyBytes]byte {
 // Encrypt a message `m` with additional data `ad` using a nonce `npub` and a secret key `k`.
 // A ciphertext (including authentication tag) and encryption status are returned.
 func Encrypt(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 
@@ -80,6 +82,7 @@ func Decrypt(c, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (m []byte
 // a nonce `npub` and a secret key `k`.
 // A ciphertext, authentication tag and encryption status are returned.
 func EncryptDetached(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c, mac []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 

--- a/crypto/aead/crypto_aead_aes256gcm.go
+++ b/crypto/aead/crypto_aead_aes256gcm.go
@@ -58,6 +58,7 @@ func (a *AES256GCM) Overhead() int {
 // Seal encrypts plaintext using nonce and additional data and appends it to a destination.
 // See aead.AEAD for details.
 func (a *AES256GCM) Seal(dst, nonce, plaintext, additionalData []byte) (ret []byte) {
+	support.CheckSizeMax(plaintext, aes256gcm.MessageBytesMax, "message")
 	support.CheckSize(nonce, a.NonceSize(), "nonce")
 
 	ret, c := appendSlices(dst, len(plaintext)+a.Overhead())
@@ -105,6 +106,7 @@ func (a *AES256GCM) Open(dst, nonce, ciphertext, additionalData []byte) (ret []b
 // SealDetached encrypts plaintext using nonce and additional data and appends it to a destination.
 // See aead.AEAD for details.
 func (a *AES256GCM) SealDetached(dst, nonce, plaintext, additionalData []byte) (ret, mac []byte) {
+	support.CheckSizeMax(plaintext, aes256gcm.MessageBytesMax, "message")
 	support.CheckSize(nonce, a.NonceSize(), "nonce")
 
 	ret, c := appendSlices(dst, len(plaintext))

--- a/crypto/aead/xchacha20poly1305ietf/crypto_aead_xchacha20poly1305_ietf.go
+++ b/crypto/aead/xchacha20poly1305ietf/crypto_aead_xchacha20poly1305_ietf.go
@@ -14,10 +14,11 @@ func init() {
 
 // Sizes of nonces, key and mac.
 const (
-	KeyBytes   int = C.crypto_aead_xchacha20poly1305_ietf_KEYBYTES  // Size of a secret key in bytes
-	NSecBytes  int = C.crypto_aead_xchacha20poly1305_ietf_NSECBYTES // Size of a secret nonce in bytes
-	NonceBytes int = C.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES // Size of a nonce in bytes
-	ABytes     int = C.crypto_aead_xchacha20poly1305_ietf_ABYTES    // Size of an authentication tag in bytes
+	KeyBytes        = C.crypto_aead_xchacha20poly1305_ietf_KEYBYTES         // Size of a secret key in bytes
+	NSecBytes       = C.crypto_aead_xchacha20poly1305_ietf_NSECBYTES        // Size of a secret nonce in bytes
+	NonceBytes      = C.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES        // Size of a nonce in bytes
+	ABytes          = C.crypto_aead_xchacha20poly1305_ietf_ABYTES           // Size of an authentication tag in bytes
+	MessageBytesMax = C.crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX // Maximum size of a message
 )
 
 // GenerateKey generates a secret key
@@ -30,6 +31,7 @@ func GenerateKey() *[KeyBytes]byte {
 // Encrypt a message `m` with additional data `ad` using a nonce `npub` and a secret key `k`.
 // A ciphertext (including authentication tag) and encryption status are returned.
 func Encrypt(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 
@@ -80,6 +82,7 @@ func Decrypt(c, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (m []byte
 // a nonce `npub` and a secret key `k`.
 // A ciphertext, authentication tag and encryption status are returned.
 func EncryptDetached(m, ad []byte, nonce *[NonceBytes]byte, k *[KeyBytes]byte) (c, mac []byte) {
+	support.CheckSizeMax(m, MessageBytesMax, "message")
 	support.NilPanic(k == nil, "secret key")
 	support.NilPanic(nonce == nil, "nonce")
 

--- a/support/support.go
+++ b/support/support.go
@@ -18,7 +18,15 @@ func CheckSize(buf []byte, expected int, descrip string) {
 // and panics when this is not the case.
 func CheckSizeMin(buf []byte, min int, descrip string) {
 	if len(buf) < min {
-		panic(fmt.Sprintf("Incorrect %s buffer size, expected (>%d), got (%d).", descrip, min, len(buf)))
+		panic(fmt.Sprintf("Incorrect %s buffer size, expected (>=%d), got (%d).", descrip, min, len(buf)))
+	}
+}
+
+// CheckSizeMax checks if the length of a byte slice is less or equal than a minimum length,
+// and panics when this is not the case.
+func CheckSizeMax(buf []byte, max uint64, descrip string) {
+	if uint64(len(buf)) > max {
+		panic(fmt.Sprintf("Incorrect %s buffer size, expected (<=%d), got (%d).", descrip, max, len(buf)))
 	}
 }
 


### PR DESCRIPTION
For performing the size checks from libsodium 1.0.14 the `support.CheckSizeMax` function is added.

libsodium also added a warning to `crypto_aead_aes256gcm` (below), should we include it as well?

```
/*
 * WARNING: Despite being the most popular AEAD construction due to its
 * use in TLS, safely using AES-GCM in a different context is tricky.
 *
 * No more than ~ 350 GB of input data should be encrypted with a given key.
 * This is for ~ 16 KB messages -- Actual figures vary according to
 * message sizes.
 *
 * In addition, nonces are short and repeated nonces would totally destroy
 * the security of this scheme.
 *
 * Nonces should thus come from atomic counters, which can be difficult to
 * set up in a distributed environment.
 *
 * Unless you absolutely need AES-GCM, use crypto_aead_xchacha20poly1305_ietf_*()
 * instead. It doesn't have any of these limitations.
 * Or, if you don't need to authenticate additional data, just stick to
 * crypto_secretbox().
 */
```