### PR TITLE
Crypto hash and generichash

### DIFF
--- a/crypto/generichash/crypto_generichash.go
+++ b/crypto/generichash/crypto_generichash.go
@@ -1,3 +1,4 @@
+// Package generichash contains the libsodium bindings for generic hashing.
 package generichash
 
 // #cgo pkg-config: libsodium
@@ -9,15 +10,15 @@ import (
 	"hash"
 )
 
-// Sizes of arguments
+// The following constants reflect the properties of the generic hash:
 const (
-	BytesMin    int    = C.crypto_generichash_BYTES_MIN
-	BytesMax    int    = C.crypto_generichash_BYTES_MAX
-	Bytes       int    = C.crypto_generichash_BYTES
-	KeyBytesMin int    = C.crypto_generichash_KEYBYTES_MIN
-	KeyBytesMax int    = C.crypto_generichash_KEYBYTES_MAX
-	KeyBytes    int    = C.crypto_generichash_KEYBYTES
-	Primitive   string = C.crypto_generichash_PRIMITIVE
+	BytesMin    int    = C.crypto_generichash_BYTES_MIN    // Minimum hash size in bytes
+	BytesMax    int    = C.crypto_generichash_BYTES_MAX    // Maximum hash size in bytes
+	Bytes       int    = C.crypto_generichash_BYTES        // Default hash size in bytes
+	KeyBytesMin int    = C.crypto_generichash_KEYBYTES_MIN // Minimum key size in bytes
+	KeyBytesMax int    = C.crypto_generichash_KEYBYTES_MAX // Maximum key size in bytes
+	KeyBytes    int    = C.crypto_generichash_KEYBYTES     // Default key size in bytes
+	Primitive   string = C.crypto_generichash_PRIMITIVE    // Name of the algorithm used for generic hashing
 )
 
 type state struct {
@@ -25,12 +26,12 @@ type state struct {
 	s *C.crypto_generichash_state
 }
 
-// Hash returns the cryptographic hash of input data `in` in output buffer `out`.
+// Sum returns the cryptographic hash of input data `in` in output buffer `out`.
 // A key `key` can be given to create a hash unique to that key.
 // The length of the hash is determined by the length of the output buffer,
 // which has to be between BytesMin and BytesMax (inclusive).
 // The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
-func Hash(out, in, key []byte) {
+func Sum(out, in, key []byte) {
 	support.CheckSizeInRange(out, BytesMin, BytesMax, "out")
 
 	if len(key) > 0 {
@@ -43,11 +44,11 @@ func Hash(out, in, key []byte) {
 		(*C.uchar)(support.BytePointer(key)), C.size_t(len(key)))
 }
 
-// NewHash returns a new hash.Hash for computing the generic hash.
+// New returns a new hash.Sum for computing the generic hash.
 // A key `key` can be given to create a hash unique to that key.
 // `size` determines the length of the hash and has to be between BytesMin and BytesMax.
 // The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
-func NewHash(size int, key []byte) hash.Hash {
+func New(size int, key []byte) hash.Hash {
 	support.CheckIntInRange(size, BytesMin, BytesMax, "hash size")
 
 	if len(key) > 0 {

--- a/crypto/generichash/crypto_generichash.go
+++ b/crypto/generichash/crypto_generichash.go
@@ -1,0 +1,111 @@
+package generichash
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import (
+	"github.com/GoKillers/libsodium-go/support"
+	"hash"
+)
+
+// Sizes of arguments
+const (
+	BytesMin    int    = C.crypto_generichash_BYTES_MIN
+	BytesMax    int    = C.crypto_generichash_BYTES_MAX
+	Bytes       int    = C.crypto_generichash_BYTES
+	KeyBytesMin int    = C.crypto_generichash_KEYBYTES_MIN
+	KeyBytesMax int    = C.crypto_generichash_KEYBYTES_MAX
+	KeyBytes    int    = C.crypto_generichash_KEYBYTES
+	Primitive   string = C.crypto_generichash_PRIMITIVE
+)
+
+type state struct {
+	l C.size_t
+	s *C.crypto_generichash_state
+}
+
+// Hash returns the cryptographic hash of input data `in` in output buffer `out`.
+// A key `key` can be given to create a hash unique to that key.
+// The length of the hash is determined by the length of the output buffer,
+// which has to be between BytesMin and BytesMax (inclusive).
+// The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func Hash(out, in, key []byte) {
+	support.CheckSizeInRange(out, BytesMin, BytesMax, "out")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, KeyBytesMin, KeyBytesMax, "key")
+	}
+
+	C.crypto_generichash(
+		(*C.uchar)(support.BytePointer(out)), C.size_t(len(out)),
+		(*C.uchar)(support.BytePointer(in)), C.ulonglong(len(in)),
+		(*C.uchar)(support.BytePointer(key)), C.size_t(len(key)))
+}
+
+// NewHash returns a new hash.Hash for computing the generic hash.
+// A key `key` can be given to create a hash unique to that key.
+// `size` determines the length of the hash and has to be between BytesMin and BytesMax.
+// The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func NewHash(size int, key []byte) hash.Hash {
+	support.CheckIntInRange(size, BytesMin, BytesMax, "hash size")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, KeyBytesMin, KeyBytesMax, "key")
+	}
+
+	s := &state{
+		l: C.size_t(size),
+		s: new(C.crypto_generichash_state),
+	}
+
+	C.crypto_generichash_init(s.s,
+		(*C.uchar)(support.BytePointer(key)),
+		C.size_t(len(key)),
+		s.l)
+
+	return s
+}
+
+// Write adds data to the running hash.
+func (s *state) Write(p []byte) (int, error) {
+	C.crypto_generichash_update(s.s,
+		(*C.uchar)(support.BytePointer(p)),
+		C.ulonglong(len(p)))
+
+	return len(p), nil
+}
+
+// Sum returns the calculated hash appended to `b`.
+func (s *state) Sum(b []byte) []byte {
+	out := append(b, make([]byte, s.l)...)
+
+	C.crypto_generichash_final(s.s,
+		(*C.uchar)(&out[len(b)]),
+		s.l)
+
+	return out
+}
+
+// Reset resets the hash to its initial state.
+func (s *state) Reset() {
+	panic("This hash can not be reset")
+}
+
+// Size returns the number of bytes Sum will return.
+func (s *state) Size() int {
+	return int(s.l)
+}
+
+// Block size returns the underlying block size.
+// This is not exposed by libsodium, so it returns 1.
+func (s *state) BlockSize() int {
+	return 1
+}
+
+// GenerateKey generates a key for use with the generic hash
+func GenerateKey() []byte {
+	k := make([]byte, KeyBytes)
+	C.crypto_generichash_keygen((*C.uchar)(&k[0]))
+	return k
+}

--- a/crypto/generichash/crypto_generichash_blake2b.go
+++ b/crypto/generichash/crypto_generichash_blake2b.go
@@ -9,16 +9,16 @@ import (
 	"hash"
 )
 
-// Sizes of arguments
+// The following constants reflect the properties of the Blake2b hash:
 const (
-	Blake2bBytesMin      int = C.crypto_generichash_blake2b_BYTES_MIN
-	Blake2bBytesMax      int = C.crypto_generichash_blake2b_BYTES_MAX
-	Blake2bBytes         int = C.crypto_generichash_blake2b_BYTES
-	Blake2bKeyBytesMin   int = C.crypto_generichash_blake2b_KEYBYTES_MIN
-	Blake2bKeyBytesMax   int = C.crypto_generichash_blake2b_KEYBYTES_MAX
-	Blake2bKeyBytes      int = C.crypto_generichash_blake2b_KEYBYTES
-	Blake2bSaltBytes     int = C.crypto_generichash_blake2b_SALTBYTES
-	Blake2bPersonalBytes int = C.crypto_generichash_blake2b_PERSONALBYTES
+	Blake2bBytesMin      int = C.crypto_generichash_blake2b_BYTES_MIN     // Minimum hash size in bytes
+	Blake2bBytesMax      int = C.crypto_generichash_blake2b_BYTES_MAX     // Maximum hash size in bytes
+	Blake2bBytes         int = C.crypto_generichash_blake2b_BYTES         // Default hash size in bytes
+	Blake2bKeyBytesMin   int = C.crypto_generichash_blake2b_KEYBYTES_MIN  // Minimum key size in bytes
+	Blake2bKeyBytesMax   int = C.crypto_generichash_blake2b_KEYBYTES_MAX  // Maximum key size in bytes
+	Blake2bKeyBytes      int = C.crypto_generichash_blake2b_KEYBYTES      // Default key size in bytes
+	Blake2bSaltBytes     int = C.crypto_generichash_blake2b_SALTBYTES     // Size of the salt in bytes
+	Blake2bPersonalBytes int = C.crypto_generichash_blake2b_PERSONALBYTES // Size of the personal in bytes
 )
 
 type blake2b struct {
@@ -26,12 +26,12 @@ type blake2b struct {
 	s *C.crypto_generichash_blake2b_state
 }
 
-// Blake2b returns the Blake2b hash of input data `in` in output buffer `out`.
+// SumBlake2b returns the Blake2b hash of input data `in` in output buffer `out`.
 // A key `key` can be given to create a hash unique to that key.
 // The length of the hash is determined by the length of the output buffer,
 // which has to be between BytesMin and BytesMax (inclusive).
 // The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
-func Blake2b(out, in, key []byte) {
+func SumBlake2b(out, in, key []byte) {
 	support.CheckSizeInRange(out, Blake2bBytesMin, Blake2bBytesMax, "out")
 
 	if len(key) > 0 {
@@ -44,12 +44,12 @@ func Blake2b(out, in, key []byte) {
 		(*C.uchar)(support.BytePointer(key)), C.size_t(len(key)))
 }
 
-// Blake2bSaltPersonal returns the Blake2b salted and personalised hash of input data `in` in output buffer `out`.
+// SumBlake2bSaltPersonal returns the Blake2b salted and personalised hash of input data `in` in output buffer `out`.
 // A key `key` can be given to create a hash unique to that key.
 // The length of the hash is determined by the length of the output buffer,
 // which has to be between BytesMin and BytesMax (inclusive).
 // The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
-func Blake2bSaltPersonal(out, in, key, salt, personal []byte) {
+func SumBlake2bSaltPersonal(out, in, key, salt, personal []byte) {
 	support.CheckSizeInRange(out, Blake2bBytesMin, Blake2bBytesMax, "out")
 	support.CheckSize(salt, Blake2bSaltBytes, "salt")
 	support.CheckSize(personal, Blake2bPersonalBytes, "personal")
@@ -66,7 +66,7 @@ func Blake2bSaltPersonal(out, in, key, salt, personal []byte) {
 		(*C.uchar)(&personal[0]))
 }
 
-// NewBlake2b returns a new hash.Hash for computing the Blake2b hash.
+// NewBlake2b returns a new hash.Sum for computing the Blake2b hash.
 // A key `key` can be given to create a hash unique to that key.
 // `size` determines the length of the hash and has to be between BytesMin and BytesMax.
 // The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
@@ -90,7 +90,7 @@ func NewBlake2b(size int, key []byte) hash.Hash {
 	return s
 }
 
-// NewBlake2bSaltPersonal returns a new hash.Hash for computing the salted and personalised Blake2b hash.
+// NewBlake2bSaltPersonal returns a new hash.Sum for computing the salted and personalised Blake2b hash.
 // A key `key` can be given to create a hash unique to that key.
 // `size` determines the length of the hash and has to be between BytesMin and BytesMax.
 // The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
@@ -154,8 +154,8 @@ func (s *blake2b) BlockSize() int {
 	return 1
 }
 
-// GenerateBlake2bKey generates a key for use with Blake2b
-func GenerateBlake2bKey() []byte {
+// GenerateKeyBlake2b generates a key for use with Blake2b
+func GenerateKeyBlake2b() []byte {
 	k := make([]byte, Blake2bKeyBytes)
 	C.crypto_generichash_blake2b_keygen((*C.uchar)(&k[0]))
 	return k

--- a/crypto/generichash/crypto_generichash_blake2b.go
+++ b/crypto/generichash/crypto_generichash_blake2b.go
@@ -1,0 +1,162 @@
+package generichash
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import (
+	"github.com/GoKillers/libsodium-go/support"
+	"hash"
+)
+
+// Sizes of arguments
+const (
+	Blake2bBytesMin      int = C.crypto_generichash_blake2b_BYTES_MIN
+	Blake2bBytesMax      int = C.crypto_generichash_blake2b_BYTES_MAX
+	Blake2bBytes         int = C.crypto_generichash_blake2b_BYTES
+	Blake2bKeyBytesMin   int = C.crypto_generichash_blake2b_KEYBYTES_MIN
+	Blake2bKeyBytesMax   int = C.crypto_generichash_blake2b_KEYBYTES_MAX
+	Blake2bKeyBytes      int = C.crypto_generichash_blake2b_KEYBYTES
+	Blake2bSaltBytes     int = C.crypto_generichash_blake2b_SALTBYTES
+	Blake2bPersonalBytes int = C.crypto_generichash_blake2b_PERSONALBYTES
+)
+
+type blake2b struct {
+	l C.size_t
+	s *C.crypto_generichash_blake2b_state
+}
+
+// Blake2b returns the Blake2b hash of input data `in` in output buffer `out`.
+// A key `key` can be given to create a hash unique to that key.
+// The length of the hash is determined by the length of the output buffer,
+// which has to be between BytesMin and BytesMax (inclusive).
+// The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func Blake2b(out, in, key []byte) {
+	support.CheckSizeInRange(out, Blake2bBytesMin, Blake2bBytesMax, "out")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, Blake2bKeyBytesMin, Blake2bKeyBytesMax, "key")
+	}
+
+	C.crypto_generichash_blake2b(
+		(*C.uchar)(support.BytePointer(out)), C.size_t(len(out)),
+		(*C.uchar)(support.BytePointer(in)), C.ulonglong(len(in)),
+		(*C.uchar)(support.BytePointer(key)), C.size_t(len(key)))
+}
+
+// Blake2bSaltPersonal returns the Blake2b salted and personalised hash of input data `in` in output buffer `out`.
+// A key `key` can be given to create a hash unique to that key.
+// The length of the hash is determined by the length of the output buffer,
+// which has to be between BytesMin and BytesMax (inclusive).
+// The size of `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func Blake2bSaltPersonal(out, in, key, salt, personal []byte) {
+	support.CheckSizeInRange(out, Blake2bBytesMin, Blake2bBytesMax, "out")
+	support.CheckSize(salt, Blake2bSaltBytes, "salt")
+	support.CheckSize(personal, Blake2bPersonalBytes, "personal")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, Blake2bKeyBytesMin, Blake2bKeyBytesMax, "key")
+	}
+
+	C.crypto_generichash_blake2b_salt_personal(
+		(*C.uchar)(support.BytePointer(out)), C.size_t(len(out)),
+		(*C.uchar)(support.BytePointer(in)), C.ulonglong(len(in)),
+		(*C.uchar)(support.BytePointer(key)), C.size_t(len(key)),
+		(*C.uchar)(&salt[0]),
+		(*C.uchar)(&personal[0]))
+}
+
+// NewBlake2b returns a new hash.Hash for computing the Blake2b hash.
+// A key `key` can be given to create a hash unique to that key.
+// `size` determines the length of the hash and has to be between BytesMin and BytesMax.
+// The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func NewBlake2b(size int, key []byte) hash.Hash {
+	support.CheckIntInRange(size, Blake2bBytesMin, Blake2bBytesMax, "hash size")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, Blake2bKeyBytesMin, Blake2bKeyBytesMax, "key")
+	}
+
+	s := &blake2b{
+		l: C.size_t(size),
+		s: new(C.crypto_generichash_blake2b_state),
+	}
+
+	C.crypto_generichash_blake2b_init(s.s,
+		(*C.uchar)(support.BytePointer(key)),
+		C.size_t(len(key)),
+		s.l)
+
+	return s
+}
+
+// NewBlake2bSaltPersonal returns a new hash.Hash for computing the salted and personalised Blake2b hash.
+// A key `key` can be given to create a hash unique to that key.
+// `size` determines the length of the hash and has to be between BytesMin and BytesMax.
+// The size `key` can either be 0 or between KeyBytesMin and KeyBytesMax (inclusive).
+func NewBlake2bSaltPersonal(size int, key, salt, personal []byte) hash.Hash {
+	support.CheckIntInRange(size, Blake2bBytesMin, Blake2bBytesMax, "hash size")
+	support.CheckSize(salt, Blake2bSaltBytes, "salt")
+	support.CheckSize(personal, Blake2bPersonalBytes, "personal")
+
+	if len(key) > 0 {
+		support.CheckSizeInRange(key, Blake2bKeyBytesMin, Blake2bKeyBytesMax, "key")
+	}
+
+	s := &blake2b{
+		l: C.size_t(size),
+		s: new(C.crypto_generichash_blake2b_state),
+	}
+
+	C.crypto_generichash_blake2b_init_salt_personal(s.s,
+		(*C.uchar)(support.BytePointer(key)),
+		C.size_t(len(key)),
+		s.l,
+		(*C.uchar)(&salt[0]),
+		(*C.uchar)(&personal[0]))
+
+	return s
+}
+
+// Write adds data to the running hash.
+func (s *blake2b) Write(p []byte) (int, error) {
+	C.crypto_generichash_blake2b_update(s.s,
+		(*C.uchar)(support.BytePointer(p)),
+		C.ulonglong(len(p)))
+
+	return len(p), nil
+}
+
+// Sum returns the calculated hash appended to `b`.
+func (s *blake2b) Sum(b []byte) []byte {
+	out := append(b, make([]byte, s.l)...)
+
+	C.crypto_generichash_blake2b_final(s.s,
+		(*C.uchar)(&out[len(b)]),
+		s.l)
+
+	return out
+}
+
+// Reset resets the hash to its initial state.
+func (s *blake2b) Reset() {
+	panic("This hash can not be reset")
+}
+
+// Size returns the number of bytes Sum will return.
+func (s *blake2b) Size() int {
+	return int(s.l)
+}
+
+// Block size returns the underlying block size.
+// This is not exposed by libsodium, so it returns 1.
+func (s *blake2b) BlockSize() int {
+	return 1
+}
+
+// GenerateBlake2bKey generates a key for use with Blake2b
+func GenerateBlake2bKey() []byte {
+	k := make([]byte, Blake2bKeyBytes)
+	C.crypto_generichash_blake2b_keygen((*C.uchar)(&k[0]))
+	return k
+}

--- a/crypto/generichash/crypto_generichash_blake2b_test.go
+++ b/crypto/generichash/crypto_generichash_blake2b_test.go
@@ -1,0 +1,91 @@
+package generichash
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+func TestBlake2b(t *testing.T) {
+	// Check default hash size
+	if Blake2bBytes != 32 {
+		t.Errorf("Unexpected hash length: %v", Blake2bBytes)
+	}
+
+	// Test the key generation
+	if bytes.Equal(GenerateBlake2bKey(), make([]byte, Blake2bKeyBytes)) {
+		t.Error("Generated key is zero")
+	}
+
+	// Fuzzing
+	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
+
+	// Check size
+	s := NewHash(BytesMin, nil)
+
+	// Check block size
+	if s.BlockSize() != 1 {
+		t.Error("Hash block size incorrect")
+	}
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var m, k, b []byte
+		var st [Blake2bSaltBytes]byte
+		var p [Blake2bPersonalBytes]byte
+		var l int
+
+		// Fuzz the test inputs
+		f.Fuzz(&m)
+		f.Fuzz(&b)
+		f.NumElements(KeyBytesMin, KeyBytesMax).Fuzz(&k)
+		f.Fuzz(&st)
+		f.Fuzz(&p)
+		f.Fuzz(&l)
+
+		// Scale length to allowed range
+		if l < 0 {
+			l = -l
+		}
+		l = l%(BytesMax-BytesMin) + BytesMin
+
+		// Create a hash
+		h := make([]byte, l)
+		Blake2b(h, m, k)
+
+		// Create the same hash with the streaming functions
+		s = NewBlake2b(l, k)
+		s.Write(m)
+
+		// Check size
+		if s.Size() != l {
+			t.Error("Hash size mismatch")
+		}
+
+		// Compare hashes
+		if !bytes.Equal(s.Sum(b), append(b, h...)) {
+			t.Log(len(h))
+			t.Errorf("Hash verification failed for: m: %x", m)
+			t.FailNow()
+		}
+
+		// Create a salted/personalised hash
+		Blake2bSaltPersonal(h, m, k, st[:], p[:])
+
+		// Create the same hash with the streaming functions
+		s = NewBlake2bSaltPersonal(l, k, st[:], p[:])
+		s.Write(m)
+
+		// Check size
+		if s.Size() != l {
+			t.Error("Hash size mismatch")
+		}
+
+		// Compare hashes
+		if !bytes.Equal(s.Sum(b), append(b, h...)) {
+			t.Log(len(h))
+			t.Errorf("Hash verification failed for: m: %x", m)
+			t.FailNow()
+		}
+	}
+}

--- a/crypto/generichash/crypto_generichash_blake2b_test.go
+++ b/crypto/generichash/crypto_generichash_blake2b_test.go
@@ -13,7 +13,7 @@ func TestBlake2b(t *testing.T) {
 	}
 
 	// Test the key generation
-	if bytes.Equal(GenerateBlake2bKey(), make([]byte, Blake2bKeyBytes)) {
+	if bytes.Equal(GenerateKeyBlake2b(), make([]byte, Blake2bKeyBytes)) {
 		t.Error("Generated key is zero")
 	}
 
@@ -21,11 +21,11 @@ func TestBlake2b(t *testing.T) {
 	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
 
 	// Check size
-	s := NewHash(BytesMin, nil)
+	s := New(BytesMin, nil)
 
 	// Check block size
 	if s.BlockSize() != 1 {
-		t.Error("Hash block size incorrect")
+		t.Error("Sum block size incorrect")
 	}
 
 	// Run tests
@@ -51,7 +51,7 @@ func TestBlake2b(t *testing.T) {
 
 		// Create a hash
 		h := make([]byte, l)
-		Blake2b(h, m, k)
+		SumBlake2b(h, m, k)
 
 		// Create the same hash with the streaming functions
 		s = NewBlake2b(l, k)
@@ -59,18 +59,18 @@ func TestBlake2b(t *testing.T) {
 
 		// Check size
 		if s.Size() != l {
-			t.Error("Hash size mismatch")
+			t.Error("Sum size mismatch")
 		}
 
 		// Compare hashes
 		if !bytes.Equal(s.Sum(b), append(b, h...)) {
 			t.Log(len(h))
-			t.Errorf("Hash verification failed for: m: %x", m)
+			t.Errorf("Sum verification failed for: m: %x", m)
 			t.FailNow()
 		}
 
 		// Create a salted/personalised hash
-		Blake2bSaltPersonal(h, m, k, st[:], p[:])
+		SumBlake2bSaltPersonal(h, m, k, st[:], p[:])
 
 		// Create the same hash with the streaming functions
 		s = NewBlake2bSaltPersonal(l, k, st[:], p[:])
@@ -78,13 +78,13 @@ func TestBlake2b(t *testing.T) {
 
 		// Check size
 		if s.Size() != l {
-			t.Error("Hash size mismatch")
+			t.Error("Sum size mismatch")
 		}
 
 		// Compare hashes
 		if !bytes.Equal(s.Sum(b), append(b, h...)) {
 			t.Log(len(h))
-			t.Errorf("Hash verification failed for: m: %x", m)
+			t.Errorf("Sum verification failed for: m: %x", m)
 			t.FailNow()
 		}
 	}

--- a/crypto/generichash/crypto_generichash_test.go
+++ b/crypto/generichash/crypto_generichash_test.go
@@ -27,7 +27,7 @@ func Test(t *testing.T) {
 
 	// Check block size
 	if s.BlockSize() != 1 {
-		t.Error("Hash block size incorrect")
+		t.Error("Sum block size incorrect")
 	}
 
 	// Run tests
@@ -49,21 +49,21 @@ func Test(t *testing.T) {
 
 		// Create a hash
 		h := make([]byte, l)
-		Hash(h, m, k)
+		Sum(h, m, k)
 
 		// Create the same hash with the streaming functions
-		s = NewHash(l, k)
+		s = New(l, k)
 		s.Write(m)
 
 		// Check size
 		if s.Size() != l {
-			t.Error("Hash size mismatch")
+			t.Error("Sum size mismatch")
 		}
 
 		// Compare hashes
 		if !bytes.Equal(s.Sum(b), append(b, h...)) {
 			t.Log(len(h))
-			t.Errorf("Hash verification failed for: m: %x", m)
+			t.Errorf("Sum verification failed for: m: %x", m)
 			t.FailNow()
 		}
 	}

--- a/crypto/generichash/crypto_generichash_test.go
+++ b/crypto/generichash/crypto_generichash_test.go
@@ -1,0 +1,70 @@
+package generichash
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+var testCount = 25000
+
+func Test(t *testing.T) {
+	// Check algorithm name
+	if Primitive != "blake2b" {
+		t.Errorf("Incorrect primitive: %s", Primitive)
+	}
+
+	// Test the key generation
+	if bytes.Equal(GenerateKey(), make([]byte, KeyBytes)) {
+		t.Error("Generated key is zero")
+	}
+
+	// Fuzzing
+	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
+
+	// Check size
+	s := NewBlake2b(BytesMin, nil)
+
+	// Check block size
+	if s.BlockSize() != 1 {
+		t.Error("Hash block size incorrect")
+	}
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var m, k, b []byte
+		var l int
+
+		// Fuzz the test inputs
+		f.Fuzz(&m)
+		f.Fuzz(&b)
+		f.NumElements(KeyBytesMin, KeyBytesMax).Fuzz(&k)
+		f.Fuzz(&l)
+
+		// Scale length to allowed range
+		if l < 0 {
+			l = -l
+		}
+		l = l%(BytesMax-BytesMin) + BytesMin
+
+		// Create a hash
+		h := make([]byte, l)
+		Hash(h, m, k)
+
+		// Create the same hash with the streaming functions
+		s = NewHash(l, k)
+		s.Write(m)
+
+		// Check size
+		if s.Size() != l {
+			t.Error("Hash size mismatch")
+		}
+
+		// Compare hashes
+		if !bytes.Equal(s.Sum(b), append(b, h...)) {
+			t.Log(len(h))
+			t.Errorf("Hash verification failed for: m: %x", m)
+			t.FailNow()
+		}
+	}
+}

--- a/crypto/hash/crypto_hash.go
+++ b/crypto/hash/crypto_hash.go
@@ -6,14 +6,16 @@ package hash
 import "C"
 import "github.com/GoKillers/libsodium-go/support"
 
-// Bytes is the size of the hash in bytes
-const Bytes int = C.crypto_hash_BYTES
+const (
+	// Bytes is the size of the hash in bytes
+	Bytes int = C.crypto_hash_BYTES
 
-// Primitive is the name of the used algorithm
-const Primitive string = C.crypto_hash_PRIMITIVE
+	// Primitive is the name of the used algorithm
+	Primitive string = C.crypto_hash_PRIMITIVE
+)
 
-// Hash returns the cryptographic hash of input data `in`
-func Hash(in []byte) []byte {
+// Sum returns the cryptographic hash of input data `in`
+func Sum(in []byte) []byte {
 	out := make([]byte, Bytes)
 
 	C.crypto_hash(

--- a/crypto/hash/crypto_hash.go
+++ b/crypto/hash/crypto_hash.go
@@ -6,13 +6,11 @@ package hash
 import "C"
 import "github.com/GoKillers/libsodium-go/support"
 
-// Bytes represents the size of the hash in bytes
+// Bytes is the size of the hash in bytes
 const Bytes int = C.crypto_hash_BYTES
 
-// Primitive returns the name of the used algorithm
-func Primitive() string {
-	return C.GoString(C.crypto_hash_primitive())
-}
+// Primitive is the name of the used algorithm
+const Primitive string = C.crypto_hash_PRIMITIVE
 
 // Hash returns the cryptographic hash of input data `in`
 func Hash(in []byte) []byte {

--- a/crypto/hash/crypto_hash.go
+++ b/crypto/hash/crypto_hash.go
@@ -1,0 +1,27 @@
+package hash
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import "github.com/GoKillers/libsodium-go/support"
+
+// Bytes represents the size of the hash in bytes
+const Bytes int = C.crypto_hash_BYTES
+
+// Primitive returns the name of the used algorithm
+func Primitive() string {
+	return C.GoString(C.crypto_hash_primitive())
+}
+
+// Hash returns the cryptographic hash of input data `in`
+func Hash(in []byte) []byte {
+	out := make([]byte, Bytes)
+
+	C.crypto_hash(
+		(*C.uchar)(&out[0]),
+		(*C.uchar)(support.BytePointer(in)),
+		C.ulonglong(len(in)))
+
+	return out
+}

--- a/crypto/hash/crypto_hash_sha256.go
+++ b/crypto/hash/crypto_hash_sha256.go
@@ -1,0 +1,75 @@
+package hash
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import (
+	"github.com/GoKillers/libsodium-go/support"
+	"hash"
+)
+
+type sha256 C.crypto_hash_sha256_state
+
+// SHA256Bytes represents the size of the hash in bytes
+const SHA256Bytes int = C.crypto_hash_sha256_BYTES
+
+// SHA256 returns the SHA256 hash of input data `in`
+func SHA256(in []byte) []byte {
+	out := make([]byte, SHA256Bytes)
+
+	C.crypto_hash_sha256(
+		(*C.uchar)(&out[0]),
+		(*C.uchar)(support.BytePointer(in)),
+		C.ulonglong(len(in)))
+
+	return out
+}
+
+// NewSHA256 returns a new hash.Hash for computing the SHA256 checksum.
+func NewSHA256() hash.Hash {
+	state := new(sha256)
+
+	C.crypto_hash_sha256_init(
+		(*C.crypto_hash_sha256_state)(state))
+
+	return state
+}
+
+// Write adds data to the running hash.
+func (s *sha256) Write(p []byte) (int, error) {
+	C.crypto_hash_sha256_update(
+		(*C.crypto_hash_sha256_state)(s),
+		(*C.uchar)(support.BytePointer(p)),
+		(C.ulonglong)(len(p)))
+
+	return len(p), nil
+}
+
+// Sum returns the calculated hash appended to `b`.
+func (s *sha256) Sum(b []byte) []byte {
+	out := append(b, make([]byte, SHA256Bytes)...)
+
+	C.crypto_hash_sha256_final(
+		(*C.crypto_hash_sha256_state)(s),
+		(*C.uchar)(&out[len(b)]))
+
+	return out
+}
+
+// Reset resets the hash to its initial state.
+func (s *sha256) Reset() {
+	C.crypto_hash_sha256_init(
+		(*C.crypto_hash_sha256_state)(s))
+}
+
+// Size returns the number of bytes Sum will return.
+func (s *sha256) Size() int {
+	return SHA256Bytes
+}
+
+// Block size returns the underlying block size.
+// This is not exposed by libsodium, so it returns 1.
+func (s *sha256) BlockSize() int {
+	return 1
+}

--- a/crypto/hash/crypto_hash_sha256.go
+++ b/crypto/hash/crypto_hash_sha256.go
@@ -14,8 +14,8 @@ type sha256 C.crypto_hash_sha256_state
 // SHA256Bytes represents the size of the hash in bytes
 const SHA256Bytes int = C.crypto_hash_sha256_BYTES
 
-// SHA256 returns the SHA256 hash of input data `in`
-func SHA256(in []byte) []byte {
+// SumSHA256 returns the SHA256 hash of input data `in`
+func SumSHA256(in []byte) []byte {
 	out := make([]byte, SHA256Bytes)
 
 	C.crypto_hash_sha256(

--- a/crypto/hash/crypto_hash_sha256_test.go
+++ b/crypto/hash/crypto_hash_sha256_test.go
@@ -1,0 +1,47 @@
+package hash
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+func TestSHA256(t *testing.T) {
+	// Fuzzing
+	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
+
+	// Check size
+	s := NewSHA256()
+	if s.Size() != SHA256Bytes {
+		t.Error("SHA256 size mismatch")
+	}
+
+	// Check block size
+	if s.BlockSize() != 1 {
+		t.Error("SHA256 block size incorrect")
+	}
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var m, sk, b []byte
+
+		// Fuzz the test inputs
+		f.Fuzz(&m)
+		f.Fuzz(&sk)
+		f.Fuzz(&b)
+
+		// Create a hash
+		h := SHA256(m)
+
+		// Create the same hash with the streaming functions
+		s.Reset()
+		s.Write(m)
+		sh := s.Sum(b)
+
+		if !bytes.Equal(sh, append(b, h...)) {
+			t.Log(len(h))
+			t.Errorf("SHA256 streaming verification failed for: m: %x", m)
+			t.FailNow()
+		}
+	}
+}

--- a/crypto/hash/crypto_hash_sha256_test.go
+++ b/crypto/hash/crypto_hash_sha256_test.go
@@ -31,7 +31,7 @@ func TestSHA256(t *testing.T) {
 		f.Fuzz(&b)
 
 		// Create a hash
-		h := SHA256(m)
+		h := SumSHA256(m)
 
 		// Create the same hash with the streaming functions
 		s.Reset()

--- a/crypto/hash/crypto_hash_sha512.go
+++ b/crypto/hash/crypto_hash_sha512.go
@@ -14,8 +14,8 @@ type sha512 C.crypto_hash_sha512_state
 // SHA512Bytes represents the size of the hash in bytes
 const SHA512Bytes int = C.crypto_hash_sha512_BYTES
 
-// SHA512 returns the SHA512 hash of input data `in`
-func SHA512(in []byte) []byte {
+// SumSHA512 returns the SHA512 hash of input data `in`
+func SumSHA512(in []byte) []byte {
 	out := make([]byte, SHA512Bytes)
 
 	C.crypto_hash_sha512(

--- a/crypto/hash/crypto_hash_sha512.go
+++ b/crypto/hash/crypto_hash_sha512.go
@@ -1,0 +1,75 @@
+package hash
+
+// #cgo pkg-config: libsodium
+// #include <stdlib.h>
+// #include <sodium.h>
+import "C"
+import (
+	"github.com/GoKillers/libsodium-go/support"
+	"hash"
+)
+
+type sha512 C.crypto_hash_sha512_state
+
+// SHA512Bytes represents the size of the hash in bytes
+const SHA512Bytes int = C.crypto_hash_sha512_BYTES
+
+// SHA512 returns the SHA512 hash of input data `in`
+func SHA512(in []byte) []byte {
+	out := make([]byte, SHA512Bytes)
+
+	C.crypto_hash_sha512(
+		(*C.uchar)(&out[0]),
+		(*C.uchar)(support.BytePointer(in)),
+		C.ulonglong(len(in)))
+
+	return out
+}
+
+// NewSHA512 returns a new hash.Hash for computing the SHA512 checksum.
+func NewSHA512() hash.Hash {
+	state := new(sha512)
+
+	C.crypto_hash_sha512_init(
+		(*C.crypto_hash_sha512_state)(state))
+
+	return state
+}
+
+// Write adds data to the running hash.
+func (s *sha512) Write(p []byte) (int, error) {
+	C.crypto_hash_sha512_update(
+		(*C.crypto_hash_sha512_state)(s),
+		(*C.uchar)(support.BytePointer(p)),
+		(C.ulonglong)(len(p)))
+
+	return len(p), nil
+}
+
+// Sum returns the calculated hash appended to `b`.
+func (s *sha512) Sum(b []byte) []byte {
+	out := append(b, make([]byte, SHA512Bytes)...)
+
+	C.crypto_hash_sha512_final(
+		(*C.crypto_hash_sha512_state)(s),
+		(*C.uchar)(&out[len(b)]))
+
+	return out
+}
+
+// Reset resets the hash to its initial state.
+func (s *sha512) Reset() {
+	C.crypto_hash_sha512_init(
+		(*C.crypto_hash_sha512_state)(s))
+}
+
+// Size returns the number of bytes Sum will return.
+func (s *sha512) Size() int {
+	return SHA512Bytes
+}
+
+// Block size returns the underlying block size.
+// This is not exposed by libsodium, so it returns 1.
+func (s *sha512) BlockSize() int {
+	return 1
+}

--- a/crypto/hash/crypto_hash_sha512_test.go
+++ b/crypto/hash/crypto_hash_sha512_test.go
@@ -31,7 +31,7 @@ func TestSHA512(t *testing.T) {
 		f.Fuzz(&b)
 
 		// Create a hash
-		h := SHA512(m)
+		h := SumSHA512(m)
 
 		// Create the same hash with the streaming functions
 		s.Reset()

--- a/crypto/hash/crypto_hash_sha512_test.go
+++ b/crypto/hash/crypto_hash_sha512_test.go
@@ -1,0 +1,47 @@
+package hash
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+func TestSHA512(t *testing.T) {
+	// Fuzzing
+	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
+
+	// Check size
+	s := NewSHA512()
+	if s.Size() != SHA512Bytes {
+		t.Error("SHA512 size mismatch")
+	}
+
+	// Check block size
+	if s.BlockSize() != 1 {
+		t.Error("SHA512 block size incorrect")
+	}
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var m, sk, b []byte
+
+		// Fuzz the test inputs
+		f.Fuzz(&m)
+		f.Fuzz(&sk)
+		f.Fuzz(&b)
+
+		// Create a hash
+		h := SHA512(m)
+
+		// Create the same hash with the streaming functions
+		s.Reset()
+		s.Write(m)
+		sh := s.Sum(b)
+
+		if !bytes.Equal(sh, append(b, h...)) {
+			t.Log(len(h))
+			t.Errorf("SHA512 streaming verification failed for: m: %x", m)
+			t.FailNow()
+		}
+	}
+}

--- a/crypto/hash/crypto_hash_test.go
+++ b/crypto/hash/crypto_hash_test.go
@@ -10,8 +10,8 @@ var testCount = 5000
 
 func Test(t *testing.T) {
 	// Check algorithm name
-	if Primitive() != "sha512" {
-		t.Errorf("Incorrect primitive: %s", Primitive())
+	if Primitive != "sha512" {
+		t.Errorf("Incorrect primitive: %s", Primitive)
 	}
 
 	// Fuzzing

--- a/crypto/hash/crypto_hash_test.go
+++ b/crypto/hash/crypto_hash_test.go
@@ -1,0 +1,39 @@
+package hash
+
+import (
+	"bytes"
+	"github.com/google/gofuzz"
+	"testing"
+)
+
+var testCount = 5000
+
+func Test(t *testing.T) {
+	// Check algorithm name
+	if Primitive() != "sha512" {
+		t.Errorf("Incorrect primitive: %s", Primitive())
+	}
+
+	// Fuzzing
+	f := fuzz.New().NilChance(0.01).NumElements(1, 1024)
+
+	// Run tests
+	for i := 0; i < testCount; i++ {
+		var m, sk []byte
+
+		// Fuzz the test inputs
+		f.Fuzz(&m)
+		f.Fuzz(&sk)
+
+		// Create a hash
+		h := Hash(m)
+
+		// Create the same hash with SHA512
+		sh := SHA512(m)
+
+		if !bytes.Equal(sh, h) {
+			t.Errorf("Hash failed for: m: %x", m)
+			t.FailNow()
+		}
+	}
+}

--- a/crypto/hash/crypto_hash_test.go
+++ b/crypto/hash/crypto_hash_test.go
@@ -26,13 +26,13 @@ func Test(t *testing.T) {
 		f.Fuzz(&sk)
 
 		// Create a hash
-		h := Hash(m)
+		h := Sum(m)
 
 		// Create the same hash with SHA512
-		sh := SHA512(m)
+		sh := SumSHA512(m)
 
 		if !bytes.Equal(sh, h) {
-			t.Errorf("Hash failed for: m: %x", m)
+			t.Errorf("Sum failed for: m: %x", m)
 			t.FailNow()
 		}
 	}


### PR DESCRIPTION
Wrap `crypto_hash` and `crypto_generichash` in the following packages:

- `crypto/hash`
- `crypto/generichash`

Formatted, linted and tested with ~96% coverage.